### PR TITLE
Fix development install issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,17 @@ kubectl apply -f $GOPATH/github.com/operator-framework/operator-lifecycle-manage
 
 #### On minikube for testing
 
+1. Create openshift-pipeline-operator namespace
+
+   `kubectl create namespace openshift-pipelines-operator`
+
 1. Apply operator crd
 
    `kubectl apply -f deploy/crds/*_crd.yaml`
 
 1. Deploy the operator
 
-    `kubectl apply -f deploy/ -n tekton-pipelines`
+    `kubectl apply -f deploy/ -n openshift-pipelines-operator`
 
 1. Install pipeline by creating an `Install` CR
 

--- a/deploy/crds/openshift_v1alpha1_install_cr.yaml
+++ b/deploy/crds/openshift_v1alpha1_install_cr.yaml
@@ -2,5 +2,5 @@ apiVersion: tekton.dev/v1alpha1
 kind: Install
 metadata:
   name: example-install
-  namespace: tekton-pipelines
+  namespace: openshift-pipelines-operator
 spec: {}


### PR DESCRIPTION
After the default operator install namespace changes, the install following the README has some issues.   These changes fix the issues.