### PR TITLE
Use latest manifestival pkg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -253,11 +253,11 @@
   version = "v0.3.7"
 
 [[projects]]
-  digest = "1:33ebb6e7d555376a0df26a576c22b921aed11faa37a23c24436d0fca5112f0e0"
+  digest = "1:77b62b256126cfbb7d62e6f8544212bb2c4a2cd87108a6c813e23aec3aada3dc"
   name = "github.com/jcrossley3/manifestival"
   packages = ["."]
   pruneopts = "NT"
-  revision = "8f133cb9c6c9d11ce74eeee056d3fc76d5e756ca"
+  revision = "921da97b38a42f3dc6a58278cc6edb8955e02293"
 
 [[projects]]
   digest = "1:f5b9328966ccea0970b1d15075698eff0ddb3e75889560aad2e9f76b289b536a"
@@ -681,6 +681,7 @@
   digest = "1:15b5c41ff6faa4d0400557d4112d6337e1abc961c65513d44fce7922e32c9ca7"
   name = "k8s.io/apimachinery"
   packages = [
+    "pkg/api/equality",
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -76,4 +76,4 @@ required = [
 
 [[constraint]]
   name = "github.com/jcrossley3/manifestival"
-  revision = "8f133cb9c6c9d11ce74eeee056d3fc76d5e756ca"
+  revision = "921da97b38a42f3dc6a58278cc6edb8955e02293"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: openshift-pipelines-operator
           # Replace this with the built image name
-          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-1
+          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
           command:
           - openshift-pipelines-operator
           imagePullPolicy: Always

--- a/vendor/github.com/jcrossley3/manifestival/manifestival.go
+++ b/vendor/github.com/jcrossley3/manifestival/manifestival.go
@@ -1,15 +1,13 @@
 package manifestival
 
 import (
+	"context"
 	"fmt"
-	"strings"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -17,33 +15,41 @@ var (
 	log = logf.Log.WithName("manifestival")
 )
 
-type Manifest interface {
+type Manifestival interface {
+	// Either updates or creates all resources in the manifest
 	ApplyAll() error
+	// Updates or creates a particular resource
 	Apply(*unstructured.Unstructured) error
+	// Deletes all resources in the manifest
 	DeleteAll() error
+	// Deletes a particular resource
 	Delete(spec *unstructured.Unstructured) error
-	Filter(fns ...FilterFn) Manifest
+	// Transforms the resources within a Manifest; returns itself
+	Transform(fns ...Transformer) *Manifest
+	// Returns a deep copy of the matching resource read from the file
 	Find(apiVersion string, kind string, name string) *unstructured.Unstructured
-	DeepCopyResources() []unstructured.Unstructured
-	ResourceNames() []string
-	ResourceInterface(spec *unstructured.Unstructured) (dynamic.ResourceInterface, error)
+	// Returns the resource fetched from the api server, nil if not found
+	Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error)
 }
 
-type YamlManifest struct {
-	dynamicClient dynamic.Interface
-	resources     []unstructured.Unstructured
+type Manifest struct {
+	Resources []unstructured.Unstructured
+	client    client.Client
 }
 
-var _ Manifest = &YamlManifest{}
+var _ Manifestival = &Manifest{}
 
-func NewYamlManifest(pathname string, recursive bool, config *rest.Config) Manifest {
-	client, _ := dynamic.NewForConfig(config)
-	log.Info("Reading YAML file", "name", pathname)
-	return &YamlManifest{resources: Parse(pathname, recursive), dynamicClient: client}
+func NewManifest(pathname string, recursive bool, client client.Client) (Manifest, error) {
+	log.Info("Reading file", "name", pathname)
+	resources, err := Parse(pathname, recursive)
+	if err != nil {
+		return Manifest{}, err
+	}
+	return Manifest{Resources: resources, client: client}, nil
 }
 
-func (f *YamlManifest) ApplyAll() error {
-	for _, spec := range f.resources {
+func (f *Manifest) ApplyAll() error {
+	for _, spec := range f.Resources {
 		if err := f.Apply(&spec); err != nil {
 			return err
 		}
@@ -51,49 +57,31 @@ func (f *YamlManifest) ApplyAll() error {
 	return nil
 }
 
-func (f *YamlManifest) Apply(spec *unstructured.Unstructured) error {
-	resource, err := f.ResourceInterface(spec)
+func (f *Manifest) Apply(spec *unstructured.Unstructured) error {
+	current, err := f.Get(spec)
 	if err != nil {
 		return err
 	}
-	current, err := resource.Get(spec.GetName(), v1.GetOptions{})
-	if err != nil {
-		// Create new one
-		if !errors.IsNotFound(err) {
-			return err
-		}
-		log.Info("Creating", "type", spec.GroupVersionKind(), "name", spec.GetName())
-		if _, err = resource.Create(spec, v1.CreateOptions{}); err != nil {
+	if current == nil {
+		logResource("Creating", spec)
+		if err = f.client.Create(context.TODO(), spec); err != nil {
 			return err
 		}
 	} else {
 		// Update existing one
-		log.Info("Updating", "type", spec.GroupVersionKind(), "name", spec.GetName())
-		// We need to preserve the current content, specifically
-		// 'metadata.resourceVersion' and 'spec.clusterIP', so we
-		// only overwrite fields set in our resource
-		content := current.UnstructuredContent()
-		for k, v := range spec.UnstructuredContent() {
-			if k == "metadata" || k == "spec" {
-				m := v.(map[string]interface{})
-				for kn, vn := range m {
-					unstructured.SetNestedField(content, vn, k, kn)
-				}
-			} else {
-				content[k] = v
+		if UpdateChanged(spec.UnstructuredContent(), current.UnstructuredContent()) {
+			logResource("Updating", spec)
+			if err = f.client.Update(context.TODO(), current); err != nil {
+				return err
 			}
-		}
-		current.SetUnstructuredContent(content)
-		if _, err = resource.Update(current, v1.UpdateOptions{}); err != nil {
-			return err
 		}
 	}
 	return nil
 }
 
-func (f *YamlManifest) DeleteAll() error {
-	a := make([]unstructured.Unstructured, len(f.resources))
-	copy(a, f.resources)
+func (f *Manifest) DeleteAll() error {
+	a := make([]unstructured.Unstructured, len(f.Resources))
+	copy(a, f.Resources)
 	// we want to delete in reverse order
 	for left, right := 0, len(a)-1; left < right; left, right = left+1, right-1 {
 		a[left], a[right] = a[right], a[left]
@@ -106,18 +94,13 @@ func (f *YamlManifest) DeleteAll() error {
 	return nil
 }
 
-func (f *YamlManifest) Delete(spec *unstructured.Unstructured) error {
-	resource, err := f.ResourceInterface(spec)
-	if err != nil {
-		return err
+func (f *Manifest) Delete(spec *unstructured.Unstructured) error {
+	current, err := f.Get(spec)
+	if current == nil && err == nil {
+		return nil
 	}
-	if _, err = resource.Get(spec.GetName(), v1.GetOptions{}); err != nil {
-		if errors.IsNotFound(err) {
-			return nil
-		}
-	}
-	log.Info("Deleting", "type", spec.GroupVersionKind(), "name", spec.GetName())
-	if err = resource.Delete(spec.GetName(), &v1.DeleteOptions{}); err != nil {
+	logResource("Deleting", spec)
+	if err := f.client.Delete(context.TODO(), spec); err != nil {
 		// ignore GC race conditions triggered by owner references
 		if !errors.IsNotFound(err) {
 			return err
@@ -126,8 +109,22 @@ func (f *YamlManifest) Delete(spec *unstructured.Unstructured) error {
 	return nil
 }
 
-func (f *YamlManifest) Find(apiVersion string, kind string, name string) *unstructured.Unstructured {
-	for _, spec := range f.resources {
+func (f *Manifest) Get(spec *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	key := client.ObjectKey{Namespace: spec.GetNamespace(), Name: spec.GetName()}
+	result := &unstructured.Unstructured{}
+	result.SetGroupVersionKind(spec.GroupVersionKind())
+	err := f.client.Get(context.TODO(), key, result)
+	if err != nil {
+		result = nil
+		if errors.IsNotFound(err) {
+			err = nil
+		}
+	}
+	return result, err
+}
+
+func (f *Manifest) Find(apiVersion string, kind string, name string) *unstructured.Unstructured {
+	for _, spec := range f.Resources {
 		if spec.GetAPIVersion() == apiVersion &&
 			spec.GetKind() == kind &&
 			spec.GetName() == name {
@@ -137,39 +134,31 @@ func (f *YamlManifest) Find(apiVersion string, kind string, name string) *unstru
 	return nil
 }
 
-func (f *YamlManifest) DeepCopyResources() []unstructured.Unstructured {
-	result := make([]unstructured.Unstructured, len(f.resources))
-	for i, spec := range f.resources {
-		result[i] = *spec.DeepCopy()
+// We need to preserve the top-level target keys, specifically
+// 'metadata.resourceVersion', 'spec.clusterIP', and any existing
+// entries in a ConfigMap's 'data' field. So we only overwrite fields
+// set in our src resource.
+func UpdateChanged(src, tgt map[string]interface{}) bool {
+	changed := false
+	for k, v := range src {
+		if v, ok := v.(map[string]interface{}); ok {
+			if tgt[k] == nil {
+				tgt[k], changed = v, true
+			} else if UpdateChanged(v, tgt[k].(map[string]interface{})) {
+				// This could be an issue if a field in a nested src
+				// map doesn't overwrite its corresponding tgt
+				changed = true
+			}
+			continue
+		}
+		if !equality.Semantic.DeepEqual(v, tgt[k]) {
+			tgt[k], changed = v, true
+		}
 	}
-	return result
+	return changed
 }
 
-func (f *YamlManifest) ResourceNames() []string {
-	var names []string
-	for _, spec := range f.resources {
-		names = append(names, fmt.Sprintf("%s/%s (%s)", spec.GetNamespace(), spec.GetName(), spec.GroupVersionKind()))
-	}
-	return names
-}
-
-func (f *YamlManifest) ResourceInterface(spec *unstructured.Unstructured) (dynamic.ResourceInterface, error) {
-	groupVersion, err := schema.ParseGroupVersion(spec.GetAPIVersion())
-	if err != nil {
-		return nil, err
-	}
-	groupVersionResource := groupVersion.WithResource(pluralize(spec.GetKind()))
-	return f.dynamicClient.Resource(groupVersionResource).Namespace(spec.GetNamespace()), nil
-}
-
-func pluralize(kind string) string {
-	ret := strings.ToLower(kind)
-	switch {
-	case strings.HasSuffix(ret, "s"):
-		return fmt.Sprintf("%ses", ret)
-	case strings.HasSuffix(ret, "policy"):
-		return fmt.Sprintf("%sies", ret[:len(ret)-1])
-	default:
-		return fmt.Sprintf("%ss", ret)
-	}
+func logResource(msg string, spec *unstructured.Unstructured) {
+	name := fmt.Sprintf("%s/%s", spec.GetNamespace(), spec.GetName())
+	log.Info(msg, "name", name, "type", spec.GroupVersionKind())
 }

--- a/vendor/github.com/jcrossley3/manifestival/transform.go
+++ b/vendor/github.com/jcrossley3/manifestival/transform.go
@@ -1,6 +1,7 @@
 package manifestival
 
 import (
+	"os"
 	"strings"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -8,61 +9,64 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type FilterFn func(u *unstructured.Unstructured) bool
+// Transform one into another; return nil to reject/delete
+type Transformer func(u *unstructured.Unstructured) *unstructured.Unstructured
 
 type Owner interface {
 	v1.Object
 	schema.ObjectKind
 }
 
-func (f *YamlManifest) Filter(fns ...FilterFn) Manifest {
+func (f *Manifest) Transform(fns ...Transformer) *Manifest {
 	var results []unstructured.Unstructured
 OUTER:
-	for i := 0; i < len(f.resources); i++ {
-		spec := f.resources[i].DeepCopy()
+	for i := 0; i < len(f.Resources); i++ {
+		spec := f.Resources[i].DeepCopy()
 		for _, f := range fns {
-			if !f(spec) {
+			spec = f(spec)
+			if spec == nil {
 				continue OUTER
 			}
 		}
 		results = append(results, *spec)
 	}
-	f.resources = results
+	f.Resources = results
 	return f
 }
 
-func ByNamespace(ns string) FilterFn {
-	return func(u *unstructured.Unstructured) bool {
-		if strings.ToLower(u.GetKind()) == "namespace" {
-			return false
+// We assume all resources in the manifest live in the same namespace
+func InjectNamespace(ns string) Transformer {
+	namespace := resolveEnv(ns)
+	return func(u *unstructured.Unstructured) *unstructured.Unstructured {
+		switch strings.ToLower(u.GetKind()) {
+		case "namespace":
+			return nil
+		case "clusterrolebinding":
+			subjects, _, _ := unstructured.NestedFieldNoCopy(u.Object, "subjects")
+			for _, subject := range subjects.([]interface{}) {
+				m := subject.(map[string]interface{})
+				if _, ok := m["namespace"]; ok {
+					m["namespace"] = namespace
+				}
+			}
 		}
 		if !isClusterScoped(u.GetKind()) {
-			u.SetNamespace(ns)
+			u.SetNamespace(namespace)
 		}
-		return true
+		return u
 	}
 }
 
-func ByOwner(owner Owner) FilterFn {
-	return func(u *unstructured.Unstructured) bool {
+func InjectOwner(owner Owner) Transformer {
+	return func(u *unstructured.Unstructured) *unstructured.Unstructured {
 		if !isClusterScoped(u.GetKind()) {
 			// apparently reference counting for cluster-scoped
 			// resources is broken, so trust the GC only for ns-scoped
 			// dependents
 			u.SetOwnerReferences([]v1.OwnerReference{*v1.NewControllerRef(owner, owner.GroupVersionKind())})
 		}
-		return true
+		return u
 	}
-}
-
-func ByOLM(u *unstructured.Unstructured) bool {
-	switch strings.ToLower(u.GetKind()) {
-	case "namespace", "role", "rolebinding",
-		"clusterrole", "clusterrolebinding",
-		"customresourcedefinition", "serviceaccount":
-		return false
-	}
-	return true
 }
 
 func isClusterScoped(kind string) bool {
@@ -91,4 +95,11 @@ func isClusterScoped(kind string) bool {
 		return true
 	}
 	return false
+}
+
+func resolveEnv(x string) string {
+	if len(x) > 1 && x[:1] == "$" {
+		return os.Getenv(x[1:])
+	}
+	return x
 }

--- a/vendor/github.com/jcrossley3/manifestival/yaml.go
+++ b/vendor/github.com/jcrossley3/manifestival/yaml.go
@@ -1,96 +1,133 @@
 package manifestival
 
 import (
-	"bytes"
 	"io"
 	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"path"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func Parse(pathname string, recursive bool) []unstructured.Unstructured {
-	in, out := make(chan []byte, 10), make(chan unstructured.Unstructured, 10)
-	go read(pathname, recursive, in)
-	go decode(in, out)
-	result := []unstructured.Unstructured{}
-	for spec := range out {
-		result = append(result, spec)
+// Parse parses YAML files into Unstructured objects.
+//
+// It supports 5 cases today:
+// 1. pathname = path to a file --> parses that file.
+// 2. pathname = path to a directory, recursive = false --> parses all files in
+//    that directory.
+// 3. pathname = path to a directory, recursive = true --> parses all files in
+//    that directory and it's descendants
+// 4. pathname = url --> fetches the contents of that URL and parses them as YAML.
+// 5. pathname = combination of all previous cases, the string can contain
+//    multiple records (file, directory or url) separated by comma
+func Parse(pathname string, recursive bool) ([]unstructured.Unstructured, error) {
+
+	pathnames := strings.Split(pathname, ",")
+	aggregated := []unstructured.Unstructured{}
+	for _, pth := range pathnames {
+		els, err := read(pth, recursive)
+		if err != nil {
+			return nil, err
+		}
+
+		aggregated = append(aggregated, els...)
 	}
-	return result
+	return aggregated, nil
 }
 
-func read(pathname string, recursive bool, sink chan []byte) {
-	defer close(sink)
-	file, err := os.Stat(pathname)
+// read cotains a logic to distinguish the type of record in pathname
+// (file, directory or url) and calls the appropriate function
+func read(pathname string, recursive bool) ([]unstructured.Unstructured, error) {
+	if isURL(pathname) {
+		return readURL(pathname)
+	}
+
+	info, err := os.Stat(pathname)
 	if err != nil {
-		log.Error(err, "Unable to get file info")
-		return
+		return nil, err
 	}
-	if file.IsDir() {
-		readDir(pathname, recursive, sink)
-	} else {
-		readFile(pathname, sink)
+
+	if info.IsDir() {
+		return readDir(pathname, recursive)
 	}
+	return readFile(pathname)
 }
 
-func readDir(pathname string, recursive bool, sink chan []byte) {
+// readFile parses a single file.
+func readFile(pathname string) ([]unstructured.Unstructured, error) {
+	file, err := os.Open(pathname)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return decode(file)
+}
+
+// readDir parses all files in a single directory and it's descendant directories
+// if the recursive flag is set to true.
+func readDir(pathname string, recursive bool) ([]unstructured.Unstructured, error) {
 	list, err := ioutil.ReadDir(pathname)
 	if err != nil {
-		log.Error(err, "Unable to read directory")
-		return
+		return nil, err
 	}
+
+	aggregated := []unstructured.Unstructured{}
 	for _, f := range list {
 		name := path.Join(pathname, f.Name())
+		var els []unstructured.Unstructured
+
 		switch {
 		case f.IsDir() && recursive:
-			readDir(name, recursive, sink)
+			els, err = readDir(name, recursive)
 		case !f.IsDir():
-			readFile(name, sink)
+			els, err = readFile(name)
 		}
+
+		if err != nil {
+			return nil, err
+		}
+		aggregated = append(aggregated, els...)
 	}
+	return aggregated, nil
 }
 
-func readFile(filename string, sink chan []byte) {
-	file, err := os.Open(filename)
+// readURL fetches a URL and parses its contents as YAML.
+func readURL(url string) ([]unstructured.Unstructured, error) {
+	resp, err := http.Get(url)
 	if err != nil {
-		panic(err.Error())
+		return nil, err
 	}
-	manifests := yaml.NewDocumentDecoder(file)
-	defer manifests.Close()
-	buf := buffer(file)
+	defer resp.Body.Close()
+
+	return decode(resp.Body)
+}
+
+// decode consumes the given reader and parses its contents as YAML.
+func decode(reader io.Reader) ([]unstructured.Unstructured, error) {
+	decoder := yaml.NewYAMLToJSONDecoder(reader)
+	objs := []unstructured.Unstructured{}
+	var err error
 	for {
-		size, err := manifests.Read(buf)
-		if err == io.EOF {
+		out := unstructured.Unstructured{}
+		err = decoder.Decode(&out)
+		if err != nil {
 			break
 		}
-		b := make([]byte, size)
-		copy(b, buf)
-		sink <- b
+		objs = append(objs, out)
 	}
+	if err != io.EOF {
+		return nil, err
+	}
+	return objs, nil
 }
 
-func decode(in chan []byte, out chan unstructured.Unstructured) {
-	for buf := range in {
-		spec := unstructured.Unstructured{}
-		err := yaml.NewYAMLToJSONDecoder(bytes.NewReader(buf)).Decode(&spec)
-		if err != nil {
-			if err != io.EOF {
-				log.Error(err, "Unable to decode YAML; ignoring")
-			}
-			continue
-		}
-		out <- spec
-	}
-	close(out)
-}
-
-func buffer(file *os.File) []byte {
-	var size int64 = bytes.MinRead
-	if fi, err := file.Stat(); err == nil {
-		size = fi.Size()
-	}
-	return make([]byte, size)
+// isURL checks whether or not the given path parses as a URL.
+func isURL(pathname string) bool {
+	_, err := url.ParseRequestURI(pathname)
+	return err == nil
 }


### PR DESCRIPTION
`manifestival`: https://github.com/jcrossley3/manifestival is a key package used in the implementaion of this operator. The package dependency was frozen at a commit has as the package was undergoing some breaking changes. This PR moves the dependency commit hash constraint to a later one.

    The reconcile function is updated to reflect `github.com/jcrossley3/manifestival`
    package changes.
    
    Modifications include:
    - changes in mannifestival type names and function names
    - recreated resoruceNames() as manifestival pkg doesnot provide that function anymore
    - built new image and udpated it in operator.yaml
      quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
    - the new image is `not` updated in 0.3.1 csv as it is already published in community-operators repo