### PR TITLE
Use deleteOption DeletePropagationForeground while deleting resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -253,11 +253,11 @@
   version = "v0.3.7"
 
 [[projects]]
-  digest = "1:77b62b256126cfbb7d62e6f8544212bb2c4a2cd87108a6c813e23aec3aada3dc"
+  digest = "1:cb111522e454b08cbb329a859955ef50ccf9915c661a5857192b2501e6c9f277"
   name = "github.com/jcrossley3/manifestival"
   packages = ["."]
   pruneopts = "NT"
-  revision = "921da97b38a42f3dc6a58278cc6edb8955e02293"
+  revision = "501df003f7629401b107df70bfb5afe94d852997"
 
 [[projects]]
   digest = "1:f5b9328966ccea0970b1d15075698eff0ddb3e75889560aad2e9f76b289b536a"
@@ -338,6 +338,7 @@
     "pkg/leader",
     "pkg/log/zap",
     "pkg/metrics",
+    "pkg/predicate",
     "pkg/scaffold",
     "pkg/scaffold/input",
     "pkg/test",
@@ -946,11 +947,12 @@
     "github.com/operator-framework/operator-sdk/pkg/leader",
     "github.com/operator-framework/operator-sdk/pkg/log/zap",
     "github.com/operator-framework/operator-sdk/pkg/metrics",
+    "github.com/operator-framework/operator-sdk/pkg/predicate",
     "github.com/operator-framework/operator-sdk/pkg/test",
     "github.com/operator-framework/operator-sdk/pkg/test/e2eutil",
     "github.com/operator-framework/operator-sdk/version",
     "github.com/spf13/pflag",
-    "k8s.io/api/core/v1",
+    "k8s.io/api/apps/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -76,4 +76,4 @@ required = [
 
 [[constraint]]
   name = "github.com/jcrossley3/manifestival"
-  revision = "921da97b38a42f3dc6a58278cc6edb8955e02293"
+  revision = "501df003f7629401b107df70bfb5afe94d852997"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,8 +16,7 @@ spec:
       serviceAccountName: openshift-pipelines-operator
       containers:
         - name: openshift-pipelines-operator
-          # Replace this with the built image name
-          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
+          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-3
           command:
           - openshift-pipelines-operator
           imagePullPolicy: Always

--- a/pkg/controller/install/install_controller.go
+++ b/pkg/controller/install/install_controller.go
@@ -140,7 +140,9 @@ func (r *ReconcileInstall) Reconcile(request reconcile.Request) (reconcile.Resul
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			r.manifest.DeleteAll()
+			r.manifest.DeleteAll(
+				client.PropagationPolicy(metav1.DeletePropagationForeground),
+			)
 			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
@@ -175,7 +177,10 @@ func (r *ReconcileInstall) install(instance *tektonv1alpha1.Install) error {
 		mf.InjectOwner(instance),
 	}
 
-	r.manifest.Transform(tfs...)
+	err := r.manifest.Transform(tfs...)
+	if err != nil {
+		return err
+	}
 	return r.manifest.ApplyAll()
 }
 

--- a/test/e2e/openshift-pipelines-operator_test.go
+++ b/test/e2e/openshift-pipelines-operator_test.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	deploymentRetry    = 5 * time.Second
-	deploymentTimeout  = 240 * time.Second
+	deploymentTimeout  = 180 * time.Second
 	cleanupRetry       = 1 * time.Second
 	cleanupTimeout     = 5 * time.Second
 	operatorDeployment = "openshift-pipelines-operator"

--- a/vendor/github.com/jcrossley3/manifestival/yaml.go
+++ b/vendor/github.com/jcrossley3/manifestival/yaml.go
@@ -118,6 +118,9 @@ func decode(reader io.Reader) ([]unstructured.Unstructured, error) {
 		if err != nil {
 			break
 		}
+		if len(out.Object) == 0 {
+			continue
+		}
 		objs = append(objs, out)
 	}
 	if err != io.EOF {


### PR DESCRIPTION
Updates `manifestival` pkg dependency constraint

Adds DeleteOption `DeletePropagationForeground` while deleting resources
Adding `DeletePropagationForeground` delete option will delete sub-resources first while deleting any resource like Deployments

This will fix the bug where ReplicaSets and Pods being orphaned after deleting a deployment

- `quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-3` was built
- pushed to quay
- updated in `deploy/operator.yaml`