### PR TITLE
Install Openshift-Pipelines into Opreator Namespace

### DIFF
--- a/.osdk-scorecard.yaml
+++ b/.osdk-scorecard.yaml
@@ -1,4 +1,4 @@
 cr-manifest: "deploy/crds/openshift_v1alpha1_install_cr.yaml"
 init-timeout: 120
 csv-path: "deploy/olm-catalog/openshift-pipelines-operator/0.3.1/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml"
-namespace: tekton-pipelines
+namespace: openshift-pipelines-operator

--- a/deploy/olm-catalog/openshift-pipelines-operator/0.3.1/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/0.3.1/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     capabilities: Basic Install
     categories: "Developer Tools, Integration & Delivery"
     description: OpenShift Pipelines is a cloud-native CI/CD solution for building pipelines using Tekton concepts which run natively on OpenShift and Kubernetes.
-    containerImage: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-1
+    containerImage: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
     createdAt: 2019-03-15T19:44:21Z
     certified: "false"
     support: Red Hat, Inc.
@@ -94,7 +94,7 @@ spec:
     * Integrated with OpenShift Developer Console
 
     ## Installation
-    _OpenShift Pipelines Operator_ gets installed into a single namespace which would then install _OpenShift Pipelines_ in the `tekton-pipelines` namespace. _OpenShift Pipelines_ is however cluster-wide and can run pipelines created in any namespace.
+    _OpenShift Pipelines Operator_ gets installed into a single namespace which would then install _OpenShift Pipelines_ into the same namespace. _OpenShift Pipelines_ is however cluster-wide and can run pipelines created in any namespace.
 
     ## Getting Started
     In order to get familiar with _OpenShift Pipelines_ concepts and create your first pipeline, follow the [OpenShift Pipelines Tutorial](https://github.com/openshift/pipelines-tutorial).
@@ -277,7 +277,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: openshift-pipelines-operator
-                image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-1
+                image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
                 imagePullPolicy: Always
                 name: openshift-pipelines-operator
                 resources: {}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: openshift-pipelines-operator
       containers:
         - name: openshift-pipelines-operator
-          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-3
+          image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
           command:
           - openshift-pipelines-operator
           imagePullPolicy: Always

--- a/deploy/resources/v0.3.1/release.yaml
+++ b/deploy/resources/v0.3.1/release.yaml
@@ -439,6 +439,11 @@ spec:
         - quay.io/openshift-pipeline/tektoncd-pipeline-entrypoint:v0.3.1
         image:  quay.io/openshift-pipeline/tektoncd-pipeline-controller:v0.3.1
         name: tekton-pipelines-controller
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - mountPath: /etc/config-logging
           name: config-logging
@@ -464,6 +469,11 @@ spec:
       containers:
       - image:  quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.3.1
         name: webhook
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - mountPath: /etc/config-logging
           name: config-logging

--- a/olm/openshift-pipelines-operator.resources.yaml
+++ b/olm/openshift-pipelines-operator.resources.yaml
@@ -90,7 +90,7 @@ data:
           capabilities: Basic Install
           categories: "Developer Tools, Integration & Delivery"
           description: OpenShift Pipelines is a cloud-native CI/CD solution for building pipelines using Tekton concepts which run natively on OpenShift and Kubernetes.
-          containerImage: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-1
+          containerImage: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
           createdAt: 2019-03-15T19:44:21Z
           certified: "false"
           support: Red Hat, Inc.
@@ -116,9 +116,6 @@ data:
         maintainers:
         - name: Red Hat, Inc.
           email: customerservice@redhat.com
-        icon:
-        - base64data: iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAH30lEQVRYR51Zb1ATZxp/l3+2JOBdGkfUD3W8aMGOboWe5fJnGhDSQOlcbrw5erQdIcDxgQklLDSi1jtPhKywYXKDN52KQWqgokwd73oGKRhAEqsNelEoeueHOnNDTVmY82BNsU1y86a7mTUm2Q3vt9339/ye37553ud93icIWOUoKipKLy4urti+ffs7YrFYAgB4DgCQQtM9AQB8T5Lk/ZmZGevAwECPw+FYWo0rJB4jpVKZpNPpmiUSSRMAIC0eWwRB/udyuYxarfY4AMDH15avwCS73f6pSCT6LV/iWLiFhYVP8/Pz3+MjlFOgXq9Xl5eX/wMAkBDm9AlJkmP9/f39FEVdOXv27EPWfEJpaemLtbW1e5OSkvYJBIJtAIBwX77e3t43TCbTaKyPiSnw8uXLH2dkZFSzCfx+v6ejo0PT19d3HQAQ4LmiSTiOlxYWFpoTExNfYNt4PJ6/qFSq96PxRBXocDiuCoVCOcvwSUtLi+r8+fPjPEVFhLW3t/9OpVL1AwASGcDy8vIXMplMFckgokCHw3FNKBTmMgYURf1TKpW+yidmeIpPvnPnzl2/37+FJfKKTCbbE27/jECHw3FWKBSWsgz/JpPJfs3TcVywycnJvrS0tDLGaH5+vrugoOCpkHpKYH19fX5FRUUoaJeWlobkcnlRDK8w78HNw8Qiw8c8/wAA8MdS7XA4PhcKhW8ymHPnzv3y2LFjLuaZLTDR7XZ/DwBIgpMJCQn3d+zYsTUauUgkSj948MNHHEtGYZheyLWs09PT93w+H9zpcKygKJrKfFhIoN1u/0wkEv2GBvlRFH0eAABPhIijpKQkOy9vzxSH82UM03Mm9M2bNz938eJFikllU1NTH2u12hrIHRSYk5OTbLFYQmKGhobeNRgMfbGcV1VVNWVlvQxPhahjfn7+iNHY+ieuFYTzOI6/o1arrQwWRVG4y/1BgYODg8TWrVsb6MnHKIoKuEjb2nBbSkqKOhbu+HGj0OPxwJXhNegQWwPBU1NTTVqttiMokD1x6dKlt5ubmwe4GAnC9A0AyIvRcchDDKvfwMXDnm9ra/t9cXExzJEAnt07d+5ciyiVygyz2fwtDQygKAp35o9cxATRCXdn1EQ/OztT1d3dfYqLJ2w+xe12rzDvmpqahMjVq1cPpqent8CXFEV9LZVKX+ZDShCdMY85DNPDbMC7amF8Op3O+wKB4Bfw2eVyVSGjo6OzYrE4E76YmJio1el0f+USuGXLlrW1tbr/cuEizAfu3r333smTH0XdgGazuVGpVLZDW5IkRxG32w0LyWCuam9vz7Rarfe4HGdmZv6qurrGyYWLNP/ddw//jOP4H6PZlpWV5RgMBiZRL0KBML0kQwMUReEOipr7GNKGhsaGTZs2EasQ+JhO3LHCgx2HXigwFOz0BoHHU8zR2Gi4vGFDRsTqI5bh4OC57GvXrt3ioE+mFw3CfFAgDORgMcpXIEF0fgMAiJFinpVAUcvjhw9/qOT6eHivYe1kPxQIz99gcuT7E2s0ezUKhRxHkJ/STCDwU7EAnwMBAC9Qz6QfDNPzCh+ohdYEKVegQLgb18Kn1tbWlwYGBv7F4yujQZ4niM7H4ZPT09PVPT2nuvnwlpaWZh84cIA54x8hIyMjX61btw4Wo+DGjRva6urqHj5EkTAlJZo9eXmvj4TNeTBMn8GXs6urq1mhULRCPEmS15Gurq56hULRCV94vd6bubm5OXzJwnFHjx67kJqaqmG/t1o/2XTr1q05vpy3b9+eCwQCwSNyfHxch8jl8p+fOHFikSaAZRZMOTGLzGjOCKITHlPM5R14vSs9hw7t1/IVB9MdawcDDMN+xhQLsOKARSKw2Wya/fv3X4yDNAjduHFjKoY1sSuXJximh90Gvjc/YDQaPygqKsJp38soiqYFBVosltacnJxmemIJRdH0eAXW1NQUbtuWOczYjYwMK202W1w3QDq9BH8Bl8t1uLKy8mhQIGxpmM3mUIIeGhraazAYPotHZGsrPrRmTcob0CYQCLgbGxteicf+9OnTdbt27TIzNiiKBosNdsl/ntXa+JEu+TnLLoaQIDqZIzNAEO3Cubm5Z9JNNMEwPGw2Wyg8FhYWevPz88shPuqliaKoaalUuoPnKiB0fQhmZu58YLFYgtUI3+F2u9kn0w8oisLYDW7UpzK+Xq9/vby8fIwhXlpa+kQul+/j4+jIkZYrXi+FGI1teXzwDMbpdNoFAkHoCLRYLLlmsxm2VYKD8+K+srJycvfu3X+Ixylf7OTkpC0tLS10r/F4PKdUKlUV2z5iye50Or8UCASvMUCKoq5LpVLpavNjuGCJRLLmwoULX4e1PuwymSw/HBtX82h8fPyturq6UCrhu1JsHI7j+9RqtYXdzqMoakQqlRZG4ovZfhseHu5ev359JdvQ5/MtmkymvVardSKOFU3GcfxdtVoNrxNwA4TGxMSEWafT1Uf7WM4GZl1dXXFlZeXfIzQwfSRJ3njw4MFpu93+xZkzZ/7DcgIbmJkKhUKenZ1dKxAIsiIIgA3MQpPJZI/1S3AKpI2T7Xb7AKs1sppfN2SzuLjYl5eXB7MD562Pr8AgOd1EPySRSDDmohWH0kc3b95sq6io6OAjLGqa4euwoKBgrUajqczKyioTi8WwERn+N4SXJMl/z87OnhkcHOwdGxtb5svNxv0f6M31w9Aq28gAAAAASUVORK5CYII=
-          mediatype: image/png
         links:
         - name: Openshift Tektoncd Pipeline GitHub Repository
           url: https://github.com/openshift/tektoncd-pipeline
@@ -155,6 +152,8 @@ data:
               version: v1
             - kind: installs
               version: v1alpha1
+            - kind: namespaces
+              version: v1
             - kind: serviceaccounts
               version: v1
             specDescriptors: []
@@ -180,7 +179,7 @@ data:
           * Integrated with OpenShift Developer Console
 
           ## Installation
-          _OpenShift Pipelines Operator_ gets installed into a single namespace which would then install _OpenShift Pipelines_ in the `tekton-pipelines` namespace. _OpenShift Pipelines_ is however cluster-wide and can run pipelines created in any namespace.
+          _OpenShift Pipelines Operator_ gets installed into a single namespace which would then install _OpenShift Pipelines_ into the same namespace. _OpenShift Pipelines_ is however cluster-wide and can run pipelines created in any namespace.
 
           ## Getting Started
           In order to get familiar with _OpenShift Pipelines_ concepts and create your first pipeline, follow the [OpenShift Pipelines Tutorial](https://github.com/openshift/pipelines-tutorial).
@@ -363,7 +362,7 @@ data:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: openshift-pipelines-operator
-                      image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-1
+                      image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.3.1-2
                       imagePullPolicy: Always
                       name: openshift-pipelines-operator
                       resources: {}

--- a/pkg/controller/install/install_controller.go
+++ b/pkg/controller/install/install_controller.go
@@ -175,6 +175,7 @@ func (r *ReconcileInstall) Reconcile(request reconcile.Request) (reconcile.Resul
 func (r *ReconcileInstall) install(instance *tektonv1alpha1.Install) error {
 	tfs := []mf.Transformer{
 		mf.InjectOwner(instance),
+		mf.InjectNamespace(instance.GetNamespace()),
 	}
 
 	err := r.manifest.Transform(tfs...)

--- a/test/e2e/openshift-pipelines-operator_test.go
+++ b/test/e2e/openshift-pipelines-operator_test.go
@@ -19,7 +19,6 @@ const (
 	cleanupRetry       = 1 * time.Second
 	cleanupTimeout     = 5 * time.Second
 	operatorDeployment = "openshift-pipelines-operator"
-	pipelinesNamespace = "tekton-pipelines"
 )
 
 func TestPipelineOperator(t *testing.T) {
@@ -33,7 +32,7 @@ func TestPipelineOperator(t *testing.T) {
 	err := framework.AddToFrameworkScheme(apis.AddToScheme, installList)
 	assertNoError(t, err)
 
-	t.Run("pipeline-operator can install pipelines", pipelineOperator)
+	t.Run("can install pipelines", pipelineOperator)
 }
 
 func pipelineOperator(t *testing.T) {
@@ -100,7 +99,7 @@ func createCR(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) erro
 	err = e2eutil.WaitForDeployment(
 		t,
 		f.KubeClient,
-		pipelinesNamespace,
+		namespace,
 		"tekton-pipelines-controller",
 		1,
 		deploymentRetry,
@@ -113,7 +112,7 @@ func createCR(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) erro
 	err = e2eutil.WaitForDeployment(
 		t,
 		f.KubeClient,
-		pipelinesNamespace,
+		namespace,
 		"tekton-pipelines-webhook",
 		1,
 		deploymentRetry,


### PR DESCRIPTION
This patch will make the Openshift-Pipelines-Operator install
Openshift-Pipelines resources (serviceaccount, deployments) into the namespace where the oprator
installed and watching.

The `tekton-pipelines` namespace will not be created any more.

This patch uses `mf.InjectNamespace(instance.GetNamespace())` function
from `manifestival` package.

At present, `SYSTEM_NAMESPACE` enviroment variable added to the release.yaml
```
env:
 - name: SYSTEM_NAMESPACE
   valueFrom:
     fieldRef:
       fieldPath: metadata.namespace
```

The addition in release.yaml is a quick fix. It will be removed in the future by adding
an `InjectEnv()` transfoermenr function.

Signed-off-by: Nikhil Thomas <nikhilthomas1@gmail.com>