### PR TITLE
Disable actions on 'manifests.tar.gz'

### DIFF
--- a/openshift-ci/Dockerfile.registry.build.next
+++ b/openshift-ci/Dockerfile.registry.build.next
@@ -1,7 +1,7 @@
 FROM quay.io/openshift/origin-operator-registry:latest
 
-COPY manifests.tar.gz .
-RUN tar zxvf manifests.tar.gz
+# COPY manifests.tar.gz .
+# RUN tar zxvf manifests.tar.gz
 RUN initializer
 
 USER 1001


### PR DESCRIPTION
Comment out operations on 'manifests.tar.gz' as it is
imporperly configured and breaking builds.

This is must be undone and is captured in issue https://github.com/openshift/tektoncd-pipeline-operator/issues/39