### PR TITLE
Add a hack to get CI running

### DIFF
--- a/openshift-ci/Dockerfile.registry.intermediate
+++ b/openshift-ci/Dockerfile.registry.intermediate
@@ -1,1 +1,8 @@
 FROM quay.io/openshift/origin-operator-registry:latest
+
+# next two lines are evil hacks
+# remove them asap
+# NT
+# june 14, 2019
+RUN mkdir out
+RUN tar -zcvf out/manifests.tar.gz deploy/olm-catalog


### PR DESCRIPTION
This hack adds a step in `Dockerfile.registry.intermediate`
to add the missing `out/manifests.tar.gz`

filed issue https://github.com/openshift/tektoncd-pipeline-operator/issues/41
