### PR TITLE
Add a hack to get CI running

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -7,6 +7,12 @@ COPY deploy/olm-catalog manifests
 RUN sed -e "s,REPLACE_IMAGE,registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:tektoncd-pipeline-operator," -i manifests/openshift-pipelines-operator/${version}/openshift-pipelines-operator.v${version}.clusterserviceversion.yaml
 RUN initializer
 
+# next two lines are evil hacks
+# remove them asap
+# NT
+# june 14, 2019
+RUN touch out/manifests.tar.gz
+
 USER 1001
 EXPOSE 50051
 CMD ["registry-server", "--termination-log=log.txt"]

--- a/openshift-ci/Dockerfile.registry.intermediate
+++ b/openshift-ci/Dockerfile.registry.intermediate
@@ -1,8 +1,1 @@
 FROM quay.io/openshift/origin-operator-registry:latest
-
-# next two lines are evil hacks
-# remove them asap
-# NT
-# june 14, 2019
-RUN mkdir out
-RUN tar -zcvf out/manifests.tar.gz deploy/olm-catalog


### PR DESCRIPTION
This hack adds a step in Dockerfile.registry.build
to add the missing out/manifests.tar.gz

filed issue #41