### PR TITLE
Add a hack to get CI running

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -11,6 +11,7 @@ RUN initializer
 # remove them asap
 # NT
 # june 14, 2019
+RUN mkdir out
 RUN touch out/manifests.tar.gz
 
 USER 1001


### PR DESCRIPTION
    This hack adds a step in `Dockerfile.registry.build`
    to add the missing `out/manifests.tar.gz`

filed https://github.com/openshift/tektoncd-pipeline-operator/issues/41