### PR TITLE
Add a hack to make sure CI builds images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ clean:
 		go build ${V_FLAG} \
 		-o ./out/operator \
 		cmd/manager/main.go
+	$(Q)cp -r deploy/olm-catalog manifests && \
+		tar -zcvf manifests.tar.gz manifests && \
+		rm -rf manifests
 
 # TODO: Disable for now for CI to go over
 upgrade-build: #TODO: reenable it

--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -7,13 +7,6 @@ COPY deploy/olm-catalog manifests
 RUN sed -e "s,REPLACE_IMAGE,registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:tektoncd-pipeline-operator," -i manifests/openshift-pipelines-operator/${version}/openshift-pipelines-operator.v${version}.clusterserviceversion.yaml
 RUN initializer
 
-# next two lines are evil hacks
-# remove them asap
-# NT
-# june 14, 2019
-RUN mkdir out
-RUN touch out/manifests.tar.gz
-
 USER 1001
 EXPOSE 50051
 CMD ["registry-server", "--termination-log=log.txt"]


### PR DESCRIPTION
Add

```
$(Q)cp -r deploy/olm-catalog manifests && \
    tar -zcvf manifests.tar.gz manifests && \
    rm -rf manifests
```

updates issue 41

Signed-off-by: Nikhil Thomas <nikhilthomas1@gmail.com>