### PR TITLE
Make tekton-pipelines as namespace

### DIFF
--- a/pkg/controller/install/install_controller.go
+++ b/pkg/controller/install/install_controller.go
@@ -179,7 +179,7 @@ func (r *ReconcileInstall) Reconcile(request reconcile.Request) (reconcile.Resul
 func (r *ReconcileInstall) install(instance *tektonv1alpha1.Install) error {
 	tfs := []mf.Transformer{
 		mf.InjectOwner(instance),
-		mf.InjectNamespace(instance.GetNamespace()),
+//		mf.InjectNamespace(instance.GetNamespace()),
 	}
 
 	err := r.manifest.Transform(tfs...)


### PR DESCRIPTION
We expect `tekton-pipelines` as the name spaces of `tekton pipelines`.
So the commented line is no needed.