### PR TITLE
Add permission to avoid exception

### DIFF
--- a/deploy/olm-catalog/openshift-pipelines-operator/0.3.1/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/0.3.1/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml
@@ -249,6 +249,7 @@ spec:
           - create
           - update
           - use
+          - delete
         serviceAccountName: openshift-pipelines-operator
       deployments:
       - name: openshift-pipelines-operator

--- a/olm/openshift-pipelines-operator.resources.yaml
+++ b/olm/openshift-pipelines-operator.resources.yaml
@@ -340,6 +340,7 @@ data:
                 - create
                 - update
                 - use
+                - delete
               serviceAccountName: openshift-pipelines-operator
             deployments:
             - name: openshift-pipelines-operator


### PR DESCRIPTION
When delete `Install` the permission denied exception will raise in logs