### PR TITLE
Set e2e test timeout to 30m

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -47,7 +47,7 @@ test-e2e: ./vendor e2e-setup
 ifeq ($(OPENSHIFT_VERSION),3)
 	$(Q)oc login -u system:admin
 endif
-	$(Q)operator-sdk test local ./test/e2e --namespace $(TEST_NAMESPACE) --up-local --go-test-flags "-v -timeout=15m"
+	$(Q)operator-sdk test local ./test/e2e --namespace $(TEST_NAMESPACE) --up-local --go-test-flags "-v -timeout=30m"
 
 
 .PHONY: e2e-setup


### PR DESCRIPTION
Tests are failing because of 15m test timeout.
Hence, setting test timeout to 30m.

Signed-off-by: Nikhil Thomas <nikhilthomas1@gmail.com>