### PR TITLE
Update operator-sdk version to 0.8.1 in build_root

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -49,7 +49,7 @@ RUN curl -L -s https://github.com/openshift/origin/releases/download/v3.11.0/ope
 # install operator-sdk (from git with no history and only the tag)
 RUN mkdir -p $GOPATH/src/github.com/operator-framework \
     && cd $GOPATH/src/github.com/operator-framework \
-    && git clone --depth 1 -b v0.7.0 https://github.com/operator-framework/operator-sdk \
+    && git clone --depth 1 -b v0.8.1 https://github.com/operator-framework/operator-sdk \
     && cd operator-sdk \
     && make dep \
     && make install


### PR DESCRIPTION
Set version on operator-sdk in Dockerfile.tools to 0.8.1