### PR TITLE
Changed install location to tekton-pipelines for Minishift

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,12 @@ cd $GOPATH/src/github.com/operator-framework/operator-lifecycle-manager
 
 1. Change directory to `${GOPATH}/src/github.com/openshift/tektoncd-pipeline-operator`
 
-1. Create `openshift-pipelines-operator` namespace
+1. Create `tekton-pipelines` namespace
 
-   `kubectl create namespace openshift-pipelines-operator`
+   `kubectl create namespace tekton-pipelines`
+
+1. Change the project to the newly created `tekton-pipelines` project 
+    `oc project tekton-pipelines `
 
 1. Apply operator crd
 

--- a/deploy/crds/openshift_v1alpha1_install_cr.yaml
+++ b/deploy/crds/openshift_v1alpha1_install_cr.yaml
@@ -2,5 +2,5 @@ apiVersion: tekton.dev/v1alpha1
 kind: Install
 metadata:
   name: example-install
-  namespace: openshift-pipelines-operator
+  namespace: tekton-pipelines
 spec: {}

--- a/deploy/olm-catalog/openshift-pipelines-operator/0.3.1/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/0.3.1/openshift-pipelines-operator.v0.3.1.clusterserviceversion.yaml
@@ -22,7 +22,7 @@ metadata:
         }
       ]
   name: openshift-pipelines-operator.v0.3.1
-  namespace: placeholder
+  namespace: tekton-pipelines
 spec:
   version: 0.3.1
   maturity: alpha

--- a/deploy/olm-catalog/openshift-pipelines-operator/0.4.0/openshift-pipelines-operator.v0.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/0.4.0/openshift-pipelines-operator.v0.4.0.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"apiVersion":"tekton.dev/v1alpha1","kind":"Install","metadata":{"name":"example-install","namespace":"openshift-pipelines-operator"},"spec":{}}]'
+    alm-examples: '[{"apiVersion":"tekton.dev/v1alpha1","kind":"Install","metadata":{"name":"example-install","namespace":"tekton-pipelines"},"spec":{}}]'
     capabilities: Basic Install
     categories: "Developer Tools, Integration & Delivery"
     description: OpenShift Pipelines is a cloud-native CI/CD solution for building pipelines using Tekton concepts which run natively on OpenShift and Kubernetes.
@@ -12,7 +12,7 @@ metadata:
     support: Red Hat, Inc.
     repository: https://github.com/openshift/tektoncd-pipeline-operator
   name: openshift-pipelines-operator.v0.4.0
-  namespace: placeholder
+  namespace: tekton-pipelines
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: openshift-pipelines-operator
-  namespace: openshift-pipelines-operator
+  namespace: tekton-pipelines
 spec:
   replicas: 1
   selector:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -6,7 +6,7 @@ subjects:
 - kind: ServiceAccount
   name: openshift-pipelines-operator
   # NOTE: replace this with the namespace the operator is deployed in.
-  namespace: openshift-pipelines-operator
+  namespace: tekton-pipelines
 roleRef:
   kind: ClusterRole
   name: openshift-pipelines-operator

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: openshift-pipelines-operator
-  namespace: openshift-pipelines-operator
+  namespace: tekton-pipelines


### PR DESCRIPTION
Changed install location to tekton-pipelines for minishift to get install to work with the Tekton dashboard as well as updating the instructions for installing on minishift 

References issue https://github.com/tektoncd/dashboard/pull/236 