### PR TITLE
Fix CI operator image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ include ./make/docker.mk
 
 .PHONY: build
 ## Build the operator
-build: ./out/operator
+build: ./out/operator ./out/build/bin manifests
 
 .PHONY: clean
 clean:
@@ -31,9 +31,15 @@ clean:
 		go build ${V_FLAG} \
 		-o ./out/operator \
 		cmd/manager/main.go
+
+./out/build/bin:
+	$(Q)mkdir -p ./out/build
+	$(Q)cp -r build/bin ./out/build/bin
+
+manifests:
 	$(Q)cp -r deploy/olm-catalog manifests && \
-		tar -zcvf manifests.tar.gz manifests && \
-		rm -rf manifests
+	tar -zcf manifests.tar.gz manifests && \
+	rm -rf manifests
 
 # TODO: Disable for now for CI to go over
 upgrade-build: #TODO: reenable it

--- a/openshift-ci/Dockerfile.deploy
+++ b/openshift-ci/Dockerfile.deploy
@@ -1,12 +1,21 @@
 FROM registry.access.redhat.com/ubi7-dev-preview/ubi-minimal:latest
+
 LABEL com.redhat.delivery.appregistry=true
 
-LABEL maintainer "Devtools <devtools@redhat.com>"
-LABEL author "Devtools <devtools@redhat.com>"
+ENV OPERATOR=/usr/local/bin/openshift-pipelines-operator \
+    USER_UID=1001 \
+    USER_NAME=openshift-pipelines-operator
 
 ENV LANG=en_US.utf8
 
-COPY operator /usr/local/bin/tektoncd-pipeline-operator
-USER 10001
+# install operator binary
+COPY operator ${OPERATOR}
 
-ENTRYPOINT [ "/usr/local/bin/tektoncd-pipeline-operator" ]
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+COPY deploy/resources /deploy/resources
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -5,8 +5,8 @@ ENV LANG=en_US.utf8
 ENV GOPATH /tmp/go
 ARG GO_PACKAGE_PATH=github.com/openshift/tektoncd-pipeline-operator
 
-ENV GIT_COMMITTER_NAME devtools
-ENV GIT_COMMITTER_EMAIL devtools@redhat.com
+ENV GIT_COMMITTER_NAME openshiftpipelines
+ENV GIT_COMMITTER_EMAIL openshiftpipelines@redhat.com
 
 RUN yum install epel-release -y \
     && yum install --enablerepo=centosplus install -y --quiet \


### PR DESCRIPTION
This patch fixes the image build step

Fix Dockerfile.deploy dockerfile to build working image

Modify Makefile `build` target to add missing files for container image build



