### PR TITLE
Test pr no namespace

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -47,7 +47,7 @@ test-e2e: ./vendor e2e-setup
 ifeq ($(OPENSHIFT_VERSION),3)
 	$(Q)oc login -u system:admin
 endif
-	$(Q)operator-sdk test local ./test/e2e --namespace $(TEST_NAMESPACE) --up-local --go-test-flags "-v -timeout=30m"
+	$(Q)operator-sdk test local ./test/e2e --image registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:tektoncd-pipeline-operator --namespace $(TEST_NAMESPACE) --go-test-flags "-v -timeout=15m"
 
 
 .PHONY: e2e-setup

--- a/make/test.mk
+++ b/make/test.mk
@@ -47,8 +47,7 @@ test-e2e: ./vendor e2e-setup
 ifeq ($(OPENSHIFT_VERSION),3)
 	$(Q)oc login -u system:admin
 endif
-	## $(Q)operator-sdk test local ./test/e2e --image registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:tektoncd-pipeline-operator --namespace $(TEST_NAMESPACE) --go-test-flags "-v -timeout=15m"
-	operator-sdk test local ./test/e2e --image nikhilvep/opo-iocib:1 --namespace $(TEST_NAMESPACE) --verbose --debug
+	$(Q)operator-sdk test local ./test/e2e --image registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:tektoncd-pipeline-operator --go-test-flags "-v -timeout=15m"
 
 .PHONY: e2e-setup
 e2e-setup: e2e-cleanup 

--- a/make/test.mk
+++ b/make/test.mk
@@ -47,8 +47,8 @@ test-e2e: ./vendor e2e-setup
 ifeq ($(OPENSHIFT_VERSION),3)
 	$(Q)oc login -u system:admin
 endif
-	$(Q)operator-sdk test local ./test/e2e --image registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:tektoncd-pipeline-operator --namespace $(TEST_NAMESPACE) --go-test-flags "-v -timeout=15m"
-
+	## $(Q)operator-sdk test local ./test/e2e --image registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:tektoncd-pipeline-operator --namespace $(TEST_NAMESPACE) --go-test-flags "-v -timeout=15m"
+	operator-sdk test local ./test/e2e --image nikhilvep/opo-iocib:1 --namespace $(TEST_NAMESPACE) --verbose --debug
 
 .PHONY: e2e-setup
 e2e-setup: e2e-cleanup 


### PR DESCRIPTION
Remove --namespace flag from test command
    
    Running tests in a namespace different from build namespace might be causing image pull errors
    
    This patch is to verify this hypothesis