### PR TITLE
fixes thrift dependency issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,5 @@ replace (
 )
 
 replace github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.9.0
+
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0


### PR DESCRIPTION
CI build fails while vendoring the dependency for thrift.

This patch fixes the the dependency issue by replace
it with right origin url

fixes https://github.com/openshift/tektoncd-pipeline-operator/issues/89