### PR TITLE
Add inject-Default-SA Transformer

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis"
 	"github.com/tektoncd/operator/pkg/controller"
-	optrFlags "github.com/tektoncd/operator/pkg/controller/flags"
+	operator "github.com/tektoncd/operator/pkg/flag"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -54,8 +54,10 @@ func main() {
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
+	// Add all flags that the operator supports
+	pflag.CommandLine.AddFlagSet(operator.FlagSet())
+
 	pflag.Parse()
-	optrFlags.Parse()
 
 	// Use a zap logr.Logger implementation. If none of the zap
 	// flags are configured (or if the zap flag set is not being

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/tektoncd/operator/pkg/apis"
 	"github.com/tektoncd/operator/pkg/controller"
+	optrFlags "github.com/tektoncd/operator/pkg/controller/flags"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -54,6 +55,7 @@ func main() {
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 
 	pflag.Parse()
+	optrFlags.Parse()
 
 	// Use a zap logr.Logger implementation. If none of the zap
 	// flags are configured (or if the zap flag set is not being

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -2,11 +2,10 @@ package config
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"github.com/tektoncd/operator/pkg/controller/rbac"
+
+	"github.com/tektoncd/operator/pkg/controller/flags"
 	"github.com/tektoncd/operator/pkg/controller/transform"
-	"path/filepath"
 
 	"github.com/go-logr/logr"
 	mf "github.com/jcrossley3/manifestival"
@@ -29,62 +28,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-const (
-	ClusterCRName   = "cluster"
-	DefaultTargetNs = "openshift-pipelines"
-
-	// Name of the pipeline controller deployment
-	PipelineControllerName = "tekton-pipelines-controller"
-	PipelineControllerSA   = "tekton-pipelines-controller"
-
-	// Name of the pipeline webhook deployment
-	PipelineWebhookName = "tekton-pipelines-webhook"
-	sccAnnotationKey    = "operator.tekton.dev"
-)
-
 var (
-	tektonVersion   = "v0.7.0"
-	resourceWatched string
-	resourceDir     string
-	targetNamespace string
-	noAutoInstall   bool
-	recursive       bool
-	ctrlLog         = logf.Log.WithName("ctrl").WithName("config")
+	ctrlLog = logf.Log.WithName("ctrl").WithName("config")
 )
 
 func init() {
-	flag.StringVar(
-		&resourceWatched, "watch-resource", ClusterCRName,
-		"cluster-wide resource that operator honours, default: "+ClusterCRName)
-
-	flag.StringVar(
-		&targetNamespace, "target-namespace", DefaultTargetNs,
-		"Namespace where pipeline will be installed default: "+DefaultTargetNs)
-
-	defaultResDir := filepath.Join("deploy", "resources", tektonVersion)
-	flag.StringVar(
-		&resourceDir, "resource-dir", defaultResDir,
-		"Path to resource manifests, default: "+defaultResDir)
-
-	flag.BoolVar(
-		&noAutoInstall, "no-auto-install", false,
-		"Do not automatically install tekton pipelines, default: false")
-
-	flag.BoolVar(
-		&recursive, "recursive", false,
-		"If enabled apply manifest file in resource directory recursively")
-
 	ctrlLog.Info("configuration",
-		"resource-watched", resourceWatched,
-		"targetNamespace", targetNamespace,
-		"no-auto-install", noAutoInstall,
+		"resource-watched", flags.ResourceWatched,
+		"targetNamespace", flags.TargetNamespace,
+		"no-auto-install", flags.NoAutoInstall,
 	)
 }
 
 // Add creates a new Config Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	m, err := mf.NewManifest(resourceDir, recursive, mgr.GetClient())
+	m, err := mf.NewManifest(flags.ResourceDir, flags.Recursive, mgr.GetClient())
 	if err != nil {
 		return err
 	}
@@ -132,7 +91,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	if noAutoInstall {
+	if flags.NoAutoInstall {
 		return nil
 	}
 
@@ -170,7 +129,7 @@ func (r *ReconcileConfig) Reconcile(req reconcile.Request) (reconcile.Result, er
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: req.Name}, cfg)
 
 	// ignore all resources except the `resourceWatched`
-	if req.Name != resourceWatched {
+	if req.Name != flags.ResourceWatched {
 		log.Info("ignoring incorrect object")
 
 		// handle resources that are not interesting as error
@@ -198,7 +157,7 @@ func (r *ReconcileConfig) Reconcile(req reconcile.Request) (reconcile.Result, er
 		return reconcile.Result{}, nil
 	}
 
-	log.Info("installing pipelines", "path", resourceDir)
+	log.Info("installing pipelines", "path", flags.ResourceDir)
 
 	return r.reconcileInstall(req, cfg)
 
@@ -207,7 +166,7 @@ func (r *ReconcileConfig) Reconcile(req reconcile.Request) (reconcile.Result, er
 func (r *ReconcileConfig) reconcileInstall(req reconcile.Request, cfg *op.Config) (reconcile.Result, error) {
 	log := requestLogger(req, "install")
 
-	err := r.updateStatus(cfg, op.ConfigCondition{Code: op.InstallingStatus, Version: tektonVersion})
+	err := r.updateStatus(cfg, op.ConfigCondition{Code: op.InstallingStatus, Version: flags.TektonVersion})
 	if err != nil {
 		log.Error(err, "failed to set status")
 		return reconcile.Result{}, err
@@ -216,7 +175,7 @@ func (r *ReconcileConfig) reconcileInstall(req reconcile.Request, cfg *op.Config
 	tfs := []mf.Transformer{
 		mf.InjectOwner(cfg),
 		mf.InjectNamespace(cfg.Spec.TargetNamespace),
-		transform.InjectDefaultSA(rbac.DefaultSA),
+		transform.InjectDefaultSA(flags.DefaultSA),
 	}
 
 	if err := r.manifest.Transform(tfs...); err != nil {
@@ -225,7 +184,7 @@ func (r *ReconcileConfig) reconcileInstall(req reconcile.Request, cfg *op.Config
 		_ = r.updateStatus(cfg, op.ConfigCondition{
 			Code:    op.ErrorStatus,
 			Details: err.Error(),
-			Version: tektonVersion})
+			Version: flags.TektonVersion})
 		return reconcile.Result{}, err
 	}
 
@@ -235,7 +194,7 @@ func (r *ReconcileConfig) reconcileInstall(req reconcile.Request, cfg *op.Config
 		_ = r.updateStatus(cfg, op.ConfigCondition{
 			Code:    op.ErrorStatus,
 			Details: err.Error(),
-			Version: tektonVersion})
+			Version: flags.TektonVersion})
 		return reconcile.Result{}, err
 	}
 	log.Info("successfully applied all resources")
@@ -249,14 +208,14 @@ func (r *ReconcileConfig) reconcileInstall(req reconcile.Request, cfg *op.Config
 
 	// add pipeline-controller to scc; scc privileged needs to be updated and
 	// can't be just oc applied
-	controller := types.NamespacedName{Namespace: cfg.Spec.TargetNamespace, Name: PipelineControllerName}
+	controller := types.NamespacedName{Namespace: cfg.Spec.TargetNamespace, Name: flags.PipelineControllerName}
 	ctrlSA, err := r.serviceAccountNameForDeployment(controller)
 	if err != nil {
 		log.Error(err, "failed to find controller service account")
 		_ = r.updateStatus(cfg, op.ConfigCondition{
 			Code:    op.ErrorStatus,
 			Details: err.Error(),
-			Version: tektonVersion})
+			Version: flags.TektonVersion})
 		return reconcile.Result{}, err
 	}
 
@@ -265,11 +224,11 @@ func (r *ReconcileConfig) reconcileInstall(req reconcile.Request, cfg *op.Config
 		_ = r.updateStatus(cfg, op.ConfigCondition{
 			Code:    op.ErrorStatus,
 			Details: err.Error(),
-			Version: tektonVersion})
+			Version: flags.TektonVersion})
 		return reconcile.Result{}, err
 	}
 
-	err = r.updateStatus(cfg, op.ConfigCondition{Code: op.InstalledStatus, Version: tektonVersion})
+	err = r.updateStatus(cfg, op.ConfigCondition{Code: op.InstalledStatus, Version: flags.TektonVersion})
 	return reconcile.Result{}, err
 }
 
@@ -294,14 +253,14 @@ func (r *ReconcileConfig) addPrivilegedSCC(sa string) error {
 	}
 
 	newList, changed := addToList(privileged.Users, sa)
-	_, annotated := privileged.Annotations[sccAnnotationKey]
+	_, annotated := privileged.Annotations[flags.SccAnnotationKey]
 	if !changed && annotated {
 		log.Info("scc already in added to the list", "action", "none")
 		return nil
 	}
 
 	log.Info("privileged scc needs updation")
-	privileged.Annotations[sccAnnotationKey] = sa
+	privileged.Annotations[flags.SccAnnotationKey] = sa
 	privileged.Users = newList
 
 	updated, err := r.secClient.SecurityContextConstraints().Update(privileged)
@@ -317,7 +276,7 @@ func (r *ReconcileConfig) removePrivilegedSCC() error {
 		return err
 	}
 
-	sa, annotated := privileged.Annotations[sccAnnotationKey]
+	sa, annotated := privileged.Annotations[flags.SccAnnotationKey]
 	if !annotated {
 		log.Info("sa already not in privileged SCC", "action", "none")
 		return nil
@@ -330,7 +289,7 @@ func (r *ReconcileConfig) removePrivilegedSCC() error {
 	}
 
 	log.Info("privileged scc needs updation")
-	delete(privileged.Annotations, sccAnnotationKey)
+	delete(privileged.Annotations, flags.SccAnnotationKey)
 	privileged.Users = newList
 
 	updated, err := r.secClient.SecurityContextConstraints().Update(privileged)
@@ -383,7 +342,7 @@ func (r *ReconcileConfig) markInvalidResource(cfg *op.Config) {
 	err := r.updateStatus(cfg,
 		op.ConfigCondition{
 			Code:    op.ErrorStatus,
-			Details: "metadata.name must be " + resourceWatched,
+			Details: "metadata.name must be " + flags.ResourceWatched,
 			Version: "unknown"})
 	if err != nil {
 		ctrlLog.Info("failed to update status as invalid")
@@ -421,12 +380,12 @@ func (r *ReconcileConfig) refreshCR(cfg *op.Config) error {
 }
 
 func createCR(c client.Client) error {
-	log := ctrlLog.WithName("create-cr").WithValues("name", resourceWatched)
+	log := ctrlLog.WithName("create-cr").WithValues("name", flags.ResourceWatched)
 	log.Info("creating a clusterwide resource of config crd")
 
 	cr := &op.Config{
-		ObjectMeta: metav1.ObjectMeta{Name: resourceWatched},
-		Spec:       op.ConfigSpec{TargetNamespace: targetNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: flags.ResourceWatched},
+		Spec:       op.ConfigSpec{TargetNamespace: flags.TargetNamespace},
 	}
 
 	err := c.Create(context.TODO(), cr)
@@ -445,7 +404,7 @@ func isUpToDate(r *op.Config) bool {
 	}
 
 	latest := c[0]
-	return latest.Version == tektonVersion &&
+	return latest.Version == flags.TektonVersion &&
 		latest.Code == op.InstalledStatus
 }
 

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/tektoncd/operator/pkg/controller/rbac"
+	"github.com/tektoncd/operator/pkg/controller/transform"
 	"path/filepath"
 
 	"github.com/go-logr/logr"
@@ -214,6 +216,7 @@ func (r *ReconcileConfig) reconcileInstall(req reconcile.Request, cfg *op.Config
 	tfs := []mf.Transformer{
 		mf.InjectOwner(cfg),
 		mf.InjectNamespace(cfg.Spec.TargetNamespace),
+		transform.InjectDefaultSA(rbac.DefaultSA),
 	}
 
 	if err := r.manifest.Transform(tfs...); err != nil {

--- a/pkg/controller/flags/flags.go
+++ b/pkg/controller/flags/flags.go
@@ -1,0 +1,64 @@
+package flags
+
+import (
+	"flag"
+	"path/filepath"
+)
+
+const (
+	// DefaultSA is the default service account
+	DefaultSA            = "pipeline"
+	DefaultIgnorePattern = "^(openshift|kube)-"
+
+	ClusterCRName   = "cluster"
+	DefaultTargetNs = "openshift-pipelines"
+
+	// Name of the pipeline controller deployment
+	PipelineControllerName = "tekton-pipelines-controller"
+	PipelineControllerSA   = "tekton-pipelines-controller"
+
+	// Name of the pipeline webhook deployment
+	PipelineWebhookName = "tekton-pipelines-webhook"
+	SccAnnotationKey    = "operator.tekton.dev"
+)
+
+var (
+	PipelineSA      string
+	IgnorePattern   string
+	TektonVersion   = "v0.7.0"
+	ResourceWatched string
+	ResourceDir     string
+	TargetNamespace string
+	NoAutoInstall   bool
+	Recursive       bool
+)
+
+func Parse() {
+	flag.StringVar(
+		&PipelineSA, "rbac-sa", DefaultSA,
+		"service account that is auto created; default: "+DefaultSA)
+	flag.StringVar(
+		&IgnorePattern, "ignore-ns-matching", DefaultIgnorePattern,
+		"Namespaces to ignore where SA will be auto-created; default: "+DefaultIgnorePattern)
+
+	flag.StringVar(
+		&ResourceWatched, "watch-resource", ClusterCRName,
+		"cluster-wide resource that operator honours, default: "+ClusterCRName)
+
+	flag.StringVar(
+		&TargetNamespace, "target-namespace", DefaultTargetNs,
+		"Namespace where pipeline will be installed default: "+DefaultTargetNs)
+
+	defaultResDir := filepath.Join("deploy", "resources", TektonVersion)
+	flag.StringVar(
+		&ResourceDir, "resource-dir", defaultResDir,
+		"Path to resource manifests, default: "+defaultResDir)
+
+	flag.BoolVar(
+		&NoAutoInstall, "no-auto-install", false,
+		"Do not automatically install tekton pipelines, default: false")
+
+	flag.BoolVar(
+		&Recursive, "recursive", false,
+		"If enabled apply manifest file in resource directory recursively")
+}

--- a/pkg/controller/rbac/rbac_controller.go
+++ b/pkg/controller/rbac/rbac_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/tektoncd/operator/pkg/controller/flags"
+	"github.com/tektoncd/operator/pkg/flag"
 
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
 	corev1 "k8s.io/api/core/v1"
@@ -46,7 +46,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
-	if _, err := regexp.Compile(flags.IgnorePattern); err != nil {
+	if _, err := regexp.Compile(flag.IgnorePattern); err != nil {
 		ctrlLog.Error(err, "Ignore regex is invalid")
 		return err
 	}
@@ -92,7 +92,7 @@ func ignoreNotFound(err error) error {
 func (r *ReconcileRBAC) Reconcile(req reconcile.Request) (reconcile.Result, error) {
 	log := ctrlLog.WithValues("req.name", req.Name)
 
-	if ignore, _ := regexp.MatchString(flags.IgnorePattern, req.Name); ignore {
+	if ignore, _ := regexp.MatchString(flag.IgnorePattern, req.Name); ignore {
 		return reconcile.Result{}, nil
 	}
 
@@ -129,9 +129,9 @@ func (r *ReconcileRBAC) getNS(req reconcile.Request) (*corev1.Namespace, error) 
 func (r *ReconcileRBAC) ensureSA(ns *corev1.Namespace) (*corev1.ServiceAccount, error) {
 	log := ctrlLog.WithName("sa")
 
-	log.Info("finding sa", "sa", flags.PipelineSA, "ns", ns.Name)
+	log.Info("finding sa", "sa", flag.PipelineSA, "ns", ns.Name)
 	sa := &corev1.ServiceAccount{}
-	saType := types.NamespacedName{Name: flags.PipelineSA, Namespace: ns.Name}
+	saType := types.NamespacedName{Name: flag.PipelineSA, Namespace: ns.Name}
 	if err := r.client.Get(context.TODO(), saType, sa); err == nil {
 		return sa, err
 	} else if !errors.IsNotFound(err) {
@@ -139,10 +139,10 @@ func (r *ReconcileRBAC) ensureSA(ns *corev1.Namespace) (*corev1.ServiceAccount, 
 	}
 
 	// create sa if not found
-	log.Info("creating sa", "sa", flags.PipelineSA, "ns", ns.Name)
+	log.Info("creating sa", "sa", flag.PipelineSA, "ns", ns.Name)
 	sa = &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      flags.PipelineSA,
+			Name:      flag.PipelineSA,
 			Namespace: ns.Name,
 		},
 	}

--- a/pkg/controller/transform/transform.go
+++ b/pkg/controller/transform/transform.go
@@ -1,0 +1,39 @@
+package transform
+
+import (
+	"strings"
+
+	mf "github.com/jcrossley3/manifestival"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// InjectDefaultSA adds default service account into config-defaults configMap
+func InjectDefaultSA(defaultSA string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		if strings.ToLower(u.GetKind()) != "configmap" {
+			return nil
+		}
+		if u.GetName() != "config-defaults" {
+			return nil
+		}
+
+		cm := &corev1.ConfigMap{}
+		err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, cm)
+		if err != nil {
+			return err
+		}
+
+		cm.Data["default-service-account"] = defaultSA
+
+		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+		if err != nil {
+			return err
+		}
+
+		u.SetUnstructuredContent(unstrObj)
+
+		return nil
+	}
+}

--- a/pkg/controller/transform/transform.go
+++ b/pkg/controller/transform/transform.go
@@ -26,14 +26,12 @@ func InjectDefaultSA(defaultSA string) mf.Transformer {
 		}
 
 		cm.Data["default-service-account"] = defaultSA
-
 		unstrObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
 		if err != nil {
 			return err
 		}
 
 		u.SetUnstructuredContent(unstrObj)
-
 		return nil
 	}
 }

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -1,8 +1,9 @@
-package flags
+package flag
 
 import (
-	"flag"
 	"path/filepath"
+
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -23,9 +24,11 @@ const (
 )
 
 var (
+	flagSet *pflag.FlagSet
+
+	TektonVersion   = "v0.7.0"
 	PipelineSA      string
 	IgnorePattern   string
-	TektonVersion   = "v0.7.0"
 	ResourceWatched string
 	ResourceDir     string
 	TargetNamespace string
@@ -33,32 +36,37 @@ var (
 	Recursive       bool
 )
 
-func Parse() {
-	flag.StringVar(
+func init() {
+	flagSet = pflag.NewFlagSet("operator", pflag.ExitOnError)
+	flagSet.StringVar(
 		&PipelineSA, "rbac-sa", DefaultSA,
 		"service account that is auto created; default: "+DefaultSA)
-	flag.StringVar(
+	flagSet.StringVar(
 		&IgnorePattern, "ignore-ns-matching", DefaultIgnorePattern,
 		"Namespaces to ignore where SA will be auto-created; default: "+DefaultIgnorePattern)
 
-	flag.StringVar(
+	flagSet.StringVar(
 		&ResourceWatched, "watch-resource", ClusterCRName,
 		"cluster-wide resource that operator honours, default: "+ClusterCRName)
 
-	flag.StringVar(
+	flagSet.StringVar(
 		&TargetNamespace, "target-namespace", DefaultTargetNs,
 		"Namespace where pipeline will be installed default: "+DefaultTargetNs)
 
 	defaultResDir := filepath.Join("deploy", "resources", TektonVersion)
-	flag.StringVar(
+	flagSet.StringVar(
 		&ResourceDir, "resource-dir", defaultResDir,
 		"Path to resource manifests, default: "+defaultResDir)
 
-	flag.BoolVar(
+	flagSet.BoolVar(
 		&NoAutoInstall, "no-auto-install", false,
 		"Do not automatically install tekton pipelines, default: false")
 
-	flag.BoolVar(
+	flagSet.BoolVar(
 		&Recursive, "recursive", false,
 		"If enabled apply manifest file in resource directory recursively")
+}
+
+func FlagSet() *pflag.FlagSet {
+	return flagSet
 }

--- a/test/testsuites/auto_default_sa.go
+++ b/test/testsuites/auto_default_sa.go
@@ -3,7 +3,7 @@ package testsuites
 import (
 	"testing"
 
-	"github.com/tektoncd/operator/pkg/controller/flags"
+	"github.com/tektoncd/operator/pkg/flag"
 
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	op "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -19,12 +19,12 @@ func ValidateDefaultSA(t *testing.T) {
 	defer ctx.Cleanup()
 
 	// ensure the controllers are running and pipeline is installed
-	cr := helpers.WaitForClusterCR(t, flags.ClusterCRName)
+	cr := helpers.WaitForClusterCR(t, flag.ClusterCRName)
 	if code := cr.Status.Conditions[0].Code; code != op.InstalledStatus {
 		t.Errorf("Expected code to be %s but got %s", op.InstalledStatus, code)
 	}
 
-	helpers.WaitForServiceAccount(t, "default", flags.DefaultSA)
+	helpers.WaitForServiceAccount(t, "default", flag.DefaultSA)
 
 	// Create a namespace
 	newNs := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foobar"}}
@@ -37,5 +37,5 @@ func ValidateDefaultSA(t *testing.T) {
 		_ = test.Global.KubeClient.CoreV1().Namespaces().Delete(ns.Name, &metav1.DeleteOptions{})
 	}()
 
-	helpers.WaitForServiceAccount(t, ns.Name, flags.DefaultSA)
+	helpers.WaitForServiceAccount(t, ns.Name, flag.DefaultSA)
 }

--- a/test/testsuites/auto_default_sa.go
+++ b/test/testsuites/auto_default_sa.go
@@ -3,10 +3,10 @@ package testsuites
 import (
 	"testing"
 
+	"github.com/tektoncd/operator/pkg/controller/flags"
+
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	op "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	"github.com/tektoncd/operator/pkg/controller/config"
-	"github.com/tektoncd/operator/pkg/controller/rbac"
 	"github.com/tektoncd/operator/test/helpers"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,12 +19,12 @@ func ValidateDefaultSA(t *testing.T) {
 	defer ctx.Cleanup()
 
 	// ensure the controllers are running and pipeline is installed
-	cr := helpers.WaitForClusterCR(t, config.ClusterCRName)
+	cr := helpers.WaitForClusterCR(t, flags.ClusterCRName)
 	if code := cr.Status.Conditions[0].Code; code != op.InstalledStatus {
 		t.Errorf("Expected code to be %s but got %s", op.InstalledStatus, code)
 	}
 
-	helpers.WaitForServiceAccount(t, "default", rbac.DefaultSA)
+	helpers.WaitForServiceAccount(t, "default", flags.DefaultSA)
 
 	// Create a namespace
 	newNs := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foobar"}}
@@ -37,5 +37,5 @@ func ValidateDefaultSA(t *testing.T) {
 		_ = test.Global.KubeClient.CoreV1().Namespaces().Delete(ns.Name, &metav1.DeleteOptions{})
 	}()
 
-	helpers.WaitForServiceAccount(t, ns.Name, rbac.DefaultSA)
+	helpers.WaitForServiceAccount(t, ns.Name, flags.DefaultSA)
 }

--- a/test/testsuites/auto_install_pipeline.go
+++ b/test/testsuites/auto_install_pipeline.go
@@ -3,9 +3,10 @@ package testsuites
 import (
 	"testing"
 
+	"github.com/tektoncd/operator/pkg/controller/flags"
+
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	op "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
-	"github.com/tektoncd/operator/pkg/controller/config"
 	"github.com/tektoncd/operator/test/helpers"
 )
 
@@ -15,14 +16,14 @@ func ValidateAutoInstall(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
 
-	cr := helpers.WaitForClusterCR(t, config.ClusterCRName)
+	cr := helpers.WaitForClusterCR(t, flags.ClusterCRName)
 	helpers.ValidatePipelineSetup(t, cr,
-		config.PipelineControllerName,
-		config.PipelineWebhookName)
+		flags.PipelineControllerName,
+		flags.PipelineWebhookName)
 
-	helpers.ValidateSCCAdded(t, cr.Spec.TargetNamespace, config.PipelineControllerName)
+	helpers.ValidateSCCAdded(t, cr.Spec.TargetNamespace, flags.PipelineControllerName)
 
-	cr = helpers.WaitForClusterCR(t, config.ClusterCRName)
+	cr = helpers.WaitForClusterCR(t, flags.ClusterCRName)
 	if code := cr.Status.Conditions[0].Code; code != op.InstalledStatus {
 		t.Errorf("Expected code to be %s but got %s", op.InstalledStatus, code)
 	}
@@ -35,15 +36,15 @@ func ValidateDeletion(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
 
-	cr := helpers.WaitForClusterCR(t, config.ClusterCRName)
+	cr := helpers.WaitForClusterCR(t, flags.ClusterCRName)
 	helpers.ValidatePipelineSetup(t, cr,
-		config.PipelineControllerName,
-		config.PipelineWebhookName)
+		flags.PipelineControllerName,
+		flags.PipelineWebhookName)
 
-	helpers.DeleteClusterCR(t, config.ClusterCRName)
+	helpers.DeleteClusterCR(t, flags.ClusterCRName)
 
 	helpers.ValidatePipelineCleanup(t, cr,
-		config.PipelineControllerName,
-		config.PipelineWebhookName)
-	helpers.ValidateSCCRemoved(t, cr.Spec.TargetNamespace, config.PipelineControllerName)
+		flags.PipelineControllerName,
+		flags.PipelineWebhookName)
+	helpers.ValidateSCCRemoved(t, cr.Spec.TargetNamespace, flags.PipelineControllerName)
 }

--- a/test/testsuites/auto_install_pipeline.go
+++ b/test/testsuites/auto_install_pipeline.go
@@ -3,7 +3,7 @@ package testsuites
 import (
 	"testing"
 
-	"github.com/tektoncd/operator/pkg/controller/flags"
+	"github.com/tektoncd/operator/pkg/flag"
 
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	op "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
@@ -16,14 +16,14 @@ func ValidateAutoInstall(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
 
-	cr := helpers.WaitForClusterCR(t, flags.ClusterCRName)
+	cr := helpers.WaitForClusterCR(t, flag.ClusterCRName)
 	helpers.ValidatePipelineSetup(t, cr,
-		flags.PipelineControllerName,
-		flags.PipelineWebhookName)
+		flag.PipelineControllerName,
+		flag.PipelineWebhookName)
 
-	helpers.ValidateSCCAdded(t, cr.Spec.TargetNamespace, flags.PipelineControllerName)
+	helpers.ValidateSCCAdded(t, cr.Spec.TargetNamespace, flag.PipelineControllerName)
 
-	cr = helpers.WaitForClusterCR(t, flags.ClusterCRName)
+	cr = helpers.WaitForClusterCR(t, flag.ClusterCRName)
 	if code := cr.Status.Conditions[0].Code; code != op.InstalledStatus {
 		t.Errorf("Expected code to be %s but got %s", op.InstalledStatus, code)
 	}
@@ -36,15 +36,15 @@ func ValidateDeletion(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
 
-	cr := helpers.WaitForClusterCR(t, flags.ClusterCRName)
+	cr := helpers.WaitForClusterCR(t, flag.ClusterCRName)
 	helpers.ValidatePipelineSetup(t, cr,
-		flags.PipelineControllerName,
-		flags.PipelineWebhookName)
+		flag.PipelineControllerName,
+		flag.PipelineWebhookName)
 
-	helpers.DeleteClusterCR(t, flags.ClusterCRName)
+	helpers.DeleteClusterCR(t, flag.ClusterCRName)
 
 	helpers.ValidatePipelineCleanup(t, cr,
-		flags.PipelineControllerName,
-		flags.PipelineWebhookName)
-	helpers.ValidateSCCRemoved(t, cr.Spec.TargetNamespace, flags.PipelineControllerName)
+		flag.PipelineControllerName,
+		flag.PipelineWebhookName)
+	helpers.ValidateSCCRemoved(t, cr.Spec.TargetNamespace, flag.PipelineControllerName)
 }


### PR DESCRIPTION
Add an `injectDefaultSA` transfor function (manifestival.Transformer)
to inject a specific service account as the `default-service-account`
in `config-defaults` configMap in payload (release.yaml) being processed

Moves constants, flags etc into a `flags` package
Updates codebase w.r.t `flags` package path

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>
(cherry picked from commit 8de6dccfb15ce72cc4443cc1d0b565ca7efb4e86)
