### PR TITLE
Update yamllint rules

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -10,7 +10,8 @@ rules:
   document-end: disable
   document-start: disable
   empty-lines: enable
-  empty-values: enable
+  empty-values:
+    level: warning
   hyphens: enable
   key-duplicates: enable
   key-ordering: disable


### PR DESCRIPTION
Set `empty-values` rules level to `warning`

The reason for this patch is the openshift/release pr: https://github.com/openshift/release/pull/5674

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>