### PR TITLE
Fix typo in  ClusterTask workingdir -> workingDir

### DIFF
--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-go/s2i-go-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-go/s2i-go-task.yaml
@@ -28,14 +28,14 @@ spec:
   steps:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command: ['s2i', 'build', '$(inputs.params.PATH_CONTEXT)', 'registry.access.redhat.com/devtools/go-toolset-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-go/s2i-go-v0-8-0-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-go/s2i-go-v0-8-0-task.yaml
@@ -28,14 +28,14 @@ spec:
   steps:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command: ['s2i', 'build', '$(inputs.params.PATH_CONTEXT)', 'registry.access.redhat.com/devtools/go-toolset-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-java-11/s2i-java-11-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-java-11/s2i-java-11-task.yaml
@@ -40,7 +40,7 @@ spec:
   steps:
     - name: gen-env-file
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /env-params
+      workingDir: /env-params
       command:
         - '/bin/sh'
         - '-c'
@@ -63,7 +63,7 @@ spec:
           mountPath: /env-params
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command:
         - 's2i'
         - 'build'
@@ -82,7 +82,7 @@ spec:
           mountPath: /env-params
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-java-11/s2i-java-11-v0-8-0-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-java-11/s2i-java-11-v0-8-0-task.yaml
@@ -40,7 +40,7 @@ spec:
   steps:
     - name: gen-env-file
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /env-params
+      workingDir: /env-params
       command:
         - '/bin/sh'
         - '-c'
@@ -63,7 +63,7 @@ spec:
           mountPath: /env-params
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command:
         - 's2i'
         - 'build'
@@ -82,7 +82,7 @@ spec:
           mountPath: /env-params
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-java-8/s2i-java-8-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-java-8/s2i-java-8-task.yaml
@@ -40,7 +40,7 @@ spec:
   steps:
     - name: gen-env-file
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /env-params
+      workingDir: /env-params
       command:
         - '/bin/sh'
         - '-c'
@@ -63,7 +63,7 @@ spec:
           mountPath: /env-params
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command:
         - 's2i'
         - 'build'
@@ -82,7 +82,7 @@ spec:
           mountPath: /env-params
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-java-8/s2i-java-8-v0-8-0-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-java-8/s2i-java-8-v0-8-0-task.yaml
@@ -40,7 +40,7 @@ spec:
   steps:
     - name: gen-env-file
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /env-params
+      workingDir: /env-params
       command:
         - '/bin/sh'
         - '-c'
@@ -63,7 +63,7 @@ spec:
           mountPath: /env-params
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command:
         - 's2i'
         - 'build'
@@ -82,7 +82,7 @@ spec:
           mountPath: /env-params
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-nodejs/s2i-nodejs-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-nodejs/s2i-nodejs-task.yaml
@@ -32,14 +32,14 @@ spec:
   steps:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command: ['s2i', 'build', '$(inputs.params.PATH_CONTEXT)', 'registry.access.redhat.com/rhscl/nodejs-$(inputs.params.VERSION)-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-nodejs/s2i-nodejs-v0-8-0-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-nodejs/s2i-nodejs-v0-8-0-task.yaml
@@ -32,14 +32,14 @@ spec:
   steps:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command: ['s2i', 'build', '$(inputs.params.PATH_CONTEXT)', 'registry.access.redhat.com/rhscl/nodejs-$(inputs.params.VERSION)-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-python-3/s2i-python-3-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-python-3/s2i-python-3-task.yaml
@@ -32,14 +32,14 @@ spec:
   steps:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command: ['s2i', 'build', '$(inputs.params.PATH_CONTEXT)', 'registry.access.redhat.com/rhscl/python-3$(inputs.params.MINOR_VERSION)-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i-python-3/s2i-python-3-v0-8-0-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i-python-3/s2i-python-3-v0-8-0-task.yaml
@@ -32,14 +32,14 @@ spec:
   steps:
     - name: generate
       image: quay.io/openshift-pipeline/s2i
-      workingdir: /workspace/source
+      workingDir: /workspace/source
       command: ['s2i', 'build', '$(inputs.params.PATH_CONTEXT)', 'registry.access.redhat.com/rhscl/python-3$(inputs.params.MINOR_VERSION)-rhel7', '--as-dockerfile', '/gen-source/Dockerfile.gen']
       volumeMounts:
         - name: gen-source
           mountPath: /gen-source
     - name: build
       image: quay.io/buildah/stable
-      workingdir: /gen-source
+      workingDir: /gen-source
       command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
       volumeMounts:
         - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i/s2i-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i/s2i-task.yaml
@@ -30,14 +30,14 @@ spec:
   steps:
   - name: generate
     image: quay.io/openshift-pipeline/s2i
-    workingdir: /workspace/source
+    workingDir: /workspace/source
     command: ['s2i', 'build', '$(inputs.params.PATH_CONTEXT)', '$(inputs.params.BUILDER_IMAGE)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
     volumeMounts:
     - name: gen-source
       mountPath: /gen-source
   - name: build
     image: quay.io/buildah/stable
-    workingdir: /gen-source
+    workingDir: /gen-source
     command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
     volumeMounts:
     - name: varlibcontainers

--- a/deploy/resources/v0.8.0/02-clustertasks/s2i/s2i-v0-8-0-task.yaml
+++ b/deploy/resources/v0.8.0/02-clustertasks/s2i/s2i-v0-8-0-task.yaml
@@ -30,14 +30,14 @@ spec:
   steps:
   - name: generate
     image: quay.io/openshift-pipeline/s2i
-    workingdir: /workspace/source
+    workingDir: /workspace/source
     command: ['s2i', 'build', '$(inputs.params.PATH_CONTEXT)', '$(inputs.params.BUILDER_IMAGE)', '--as-dockerfile', '/gen-source/Dockerfile.gen']
     volumeMounts:
     - name: gen-source
       mountPath: /gen-source
   - name: build
     image: quay.io/buildah/stable
-    workingdir: /gen-source
+    workingDir: /gen-source
     command: ['buildah', 'bud', '--tls-verify=$(inputs.params.TLSVERIFY)', '--layers', '-f', '/gen-source/Dockerfile.gen', '-t', '$(outputs.resources.image.url)', '.']
     volumeMounts:
     - name: varlibcontainers

--- a/scripts/update-tasks.sh
+++ b/scripts/update-tasks.sh
@@ -73,9 +73,13 @@ download_task() {
 # source: $task_url
 #
 ---
-$(curl -sLf "$task_url" | sed -e 's|^kind: Task|kind: ClusterTask|g' )
+$(curl -sLf "$task_url" |
+  sed -e 's|^kind: Task|kind: ClusterTask|g' \
+      -e "s|^\(\s\+\)workingdir:\(.*\)|\1workingDir:\2|g"  )
 EOF
 
+ # NOTE: helps when the original and the generated need to compared
+ # curl -sLf "$task_url"  -o "$task_path.orig"
 
 }
 
@@ -119,7 +123,9 @@ create_version() {
   local version="$1"; shift
   local task_version_path="$(dirname $task_path)/$task-$version-task.yaml"
 
-  sed -e "s|^\(\s\+name:\)\s\+\($task\)|\1 \2-$version|g"  $task_path  > "$task_version_path"
+  sed \
+    -e "s|^\(\s\+name:\)\s\+\($task\)|\1 \2-$version|g"  \
+    $task_path  > "$task_version_path"
 }
 
 
@@ -144,11 +150,9 @@ main() {
   dest_dir="$dest_dir/02-clustertasks"
   mkdir -p "$dest_dir" || die 1 "failed to create catalog dir ${catalog_dir}"
 
-  #create_version s2i "$dest_dir" "$version"  \
-    #"$TEKTON_CATALOG"   "$catalog_version"  TEKTON_CATALOG_TASKS
-
   get_tasks "$dest_dir" "$version"  \
     "$TEKTON_CATALOG"   "$catalog_version"  TEKTON_CATALOG_TASKS
+
   get_tasks "$dest_dir" "$version"  \
     "$OPENSHIFT_CATALOG"   "$catalog_version"  OPENSHIFT_CATALOG_TASKS
 


### PR DESCRIPTION
Addresses the issue https://github.com/tektoncd/catalog/issues/148 by
renaming `workingdir` to `workingDir`

See: https://github.com/tektoncd/pipeline/commit/01d7dff72bdafd0295d5c42f26fd2f18224a568f
for details

Signed-off-by: Sunil Thaha <sthaha@redhat.com>