### PR TITLE
Update operator CSV chaining

### DIFF
--- a/deploy/olm-catalog/openshift-pipelines-operator/0.8.1/openshift-pipelines-operator.v0.8.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/0.8.1/openshift-pipelines-operator.v0.8.1.clusterserviceversion.yaml
@@ -378,5 +378,7 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: openshift-pipelines-operator.v0.8.0
+  replaces: openshift-pipelines-operator.v0.7.0
+  skips:
+  - openshift-pipelines-operator.v0.8.0
   version: 0.8.1

--- a/deploy/olm-catalog/openshift-pipelines-operator/openshift-pipelines-operator.package.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/openshift-pipelines-operator.package.yaml
@@ -1,7 +1,7 @@
 channels:
 - currentCSV: openshift-pipelines-operator.v0.8.1
   name: canary
-- currentCSV: openshift-pipelines-operator.v0.7.0
+- currentCSV: openshift-pipelines-operator.v0.8.1
   name: dev-preview
 defaultChannel: dev-preview
 packageName: openshift-pipelines-operator


### PR DESCRIPTION
This patch reflects the current CSV chain pushed to operatorhub

The expected behavor is as follows

    1. Both dev-preiew and canary points to v0.8.1. Therefore all new subscriptions to either of the channels will get v0.8.1
    2. If a user is already subscribed to canary channel (v0.8.0) it will be upgraded to v0.8.1
    3. If a user is already subscribed to dev-preview channel (v0.7.0) will skip v0.8.0 and get upgraded to v0.8.1

ref: https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/how-to-update-operators.md#skipping-updates

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>