### PR TITLE
Add mechanism to fetch nightly/latest pipeline payload

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -4,14 +4,49 @@
 # Usage: update-to-head.sh
 
 set -e
-REPO_NAME=`basename $(git rev-parse --show-toplevel)`
+VERSION=$1
+BRANCH_NAME=release-next
+if [[ -n $VERSION ]]; then
+  BRANCH_NAME=release-${VERSION}
+fi
+VERSION=${VERSION:-release-next}
+
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
+REPO_NAME=`basename ${PROJECT_ROOT}`
+PAYLOAD_ROOT=${PROJECT_ROOT}/deploy/resources
 
 # Reset release-next to openshift/master.
 # as there is no upstream repository for this yet.
 # after moving openshift-pipelines-operator development to https://github.com/openshift/tektoncd-operator
 # the release-next branch should be synced from upstream/master (upstream=tektoncd/operator)
 git fetch openshift master
-git checkout openshift/master -B release-next
+git checkout openshift/master -B ${BRANCH_NAME}
+
+#create payload dir (path where pipeline, addons/triggers, addons/clustertasks are copied)
+PAYLOAD_PATH=${PAYLOAD_ROOT}/${VERSION}
+[[ -d ${PAYLOAD_PATH} ]] && rm -rf ${PAYLOAD_PATH}
+mkdir -p ${PAYLOAD_PATH}
+
+#get pipeline manifest
+${PROJECT_ROOT}/openshift/release/fetch-pipeline.sh ${VERSION} ${PAYLOAD_PATH}
+
+# copy rest of the payload from the previous release
+# TODO get triggers from nightly or latest release
+# TODO run scripts/update-tasks.sh to get cluster tasks
+#get triggers manifest
+#get cluster task manifest
+#get consoleSample
+LATEST_RELEASE=$(ls ${PAYLOAD_ROOT} | sort | tail -n 1)
+for d in $(ls ${PAYLOAD_ROOT}/${LATEST_RELEASE}); do
+  echo $d
+  if [[ "${d}" = "pipelines" ]]; then
+    continue
+  fi
+  cp -r ${PAYLOAD_ROOT}/${LATEST_RELEASE}/${d} ${PAYLOAD_PATH}/${d}
+done
+
+git add deploy/resources
+git commit -m ":Add payload: pipelines,clustertasks,triggers,consolesampleyamls"
 git push -f openshift release-next
 
 # Trigger CI


### PR DESCRIPTION
Add mechanism to fetch nightly/latest pipeline payload for nightly builds

Update update-to-head.sh to use openshift/release/fetch-pipeline.sh script

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>