### PR TITLE
Add v0.8.2 CSV

### DIFF
--- a/deploy/olm-catalog/openshift-pipelines-operator/0.8.2/openshift-pipelines-operator.v0.8.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/0.8.2/openshift-pipelines-operator.v0.8.2.clusterserviceversion.yaml
@@ -6,14 +6,14 @@ metadata:
     capabilities: Basic Install
     categories: Developer Tools, Integration & Delivery
     certified: "false"
-    containerImage: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.9.0
+    containerImage: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.8.2
     createdAt: "2019-03-15T19:44:21Z"
     description: OpenShift Pipelines is a cloud-native CI/CD solution for building
       pipelines using Tekton concepts which run natively on OpenShift and Kubernetes.
     repository: https://github.com/openshift/tektoncd-pipeline-operator
     support: Red Hat, Inc.
     operators.operatorframework.io/internal-objects: '["config.operator.tekton.dev"]'
-  name: openshift-pipelines-operator.v0.9.0
+  name: openshift-pipelines-operator.v0.8.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -348,7 +348,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: openshift-pipelines-operator
-                image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.8.1
+                image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.8.2
                 imagePullPolicy: Always
                 name: openshift-pipelines-operator
                 resources: {}
@@ -379,5 +379,5 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: openshift-pipelines-operator.v0.8.2
-  version: 0.9.0
+  replaces: openshift-pipelines-operator.v0.8.1
+  version: 0.8.2

--- a/deploy/olm-catalog/openshift-pipelines-operator/0.8.2/operator_v1alpha1_config_crd.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/0.8.2/operator_v1alpha1_config_crd.yaml
@@ -1,0 +1,66 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: config.operator.tekton.dev
+spec:
+  group: operator.tekton.dev
+  names:
+    kind: Config
+    listKind: ConfigList
+    plural: config
+    singular: config
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            targetNamespace:
+              description: namespace where OpenShift pipelines will be installed
+              type: string
+          required:
+          - targetNamespace
+          type: object
+        status:
+          properties:
+            conditions:
+              description: installation status sorted in reverse chronological order
+              items:
+                properties:
+                  code:
+                    description: Code indicates the status of installation of pipeline resources.
+                    type: string
+                  details:
+                    description: Additional details about the Code
+                    type: string
+                  version:
+                    description: The version of tekton pipelines
+                    type: string
+                required:
+                - code
+                - version
+                type: object
+              type: array
+            operatorUUID:
+              type: string
+              description: UUID of the operator that installed the pipeline
+          type: object
+  additionalPrinterColumns:
+  - JSONPath: ".status.conditions[0].code"
+    name: status
+    type: string
+    description: status of pipeline installation
+
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/openshift-pipelines-operator/openshift-pipelines-operator.package.yaml
+++ b/deploy/olm-catalog/openshift-pipelines-operator/openshift-pipelines-operator.package.yaml
@@ -1,7 +1,7 @@
 channels:
-- currentCSV: openshift-pipelines-operator.v0.8.1
+- currentCSV: openshift-pipelines-operator.v0.8.2
   name: canary
-- currentCSV: openshift-pipelines-operator.v0.8.1
+- currentCSV: openshift-pipelines-operator.v0.8.2
   name: dev-preview
 defaultChannel: dev-preview
 packageName: openshift-pipelines-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: openshift-pipelines-operator
       containers:
       - name: openshift-pipelines-operator
-        image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.8.1
+        image: quay.io/openshift-pipeline/openshift-pipelines-operator:v0.8.2
         command:
         - openshift-pipelines-operator
         - --recursive


### PR DESCRIPTION
This version fixes webhook timing issue affecting clustertasks

This patch marks config.operator.tekton.dev as internal object

We need to merge this to master so that future CSV can be generated using the `--from-csv 0.8.2` flag

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>