### PR TITLE
Updates make build target for productization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,7 @@ VENDOR_BUILD ?=
 
 .PHONY: build
 ## Build the operator
-build_prod: ./out/operator
-
-.PHONY: build
-## Build the operator
-build: ./out/operator ./out/build/bin manifests
+build: ./out/operator
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,13 @@ include ./make/test.mk
 include ./make/docker.mk
 include ./make/csv.mk
 
+BUILD_DIR ?= ./out/
+BUILD_OUT_FILE ?= operator
+VENDOR_BUILD ?= 
+
+.PHONY: build
+## Build the operator
+build_prod: ./out/operator
 
 .PHONY: build
 ## Build the operator
@@ -35,7 +42,7 @@ clean:
 	#$(Q)operator-sdk generate k8s
 	$(Q)go version
 	$(Q)CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
-		go build ${V_FLAG} -o ./out/operator \
+		go build ${V_FLAG} ${VENDOR_BUILD} -o ${BUILD_DIR}${BUILD_OUT_FILE} \
 		./cmd/manager
 
 ./out/build/bin:

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,17 @@ include ./make/test.mk
 include ./make/docker.mk
 include ./make/csv.mk
 
-BUILD_DIR ?= ./out/
-BUILD_OUT_FILE ?= operator
+BUILD_OUTPUT_DIR ?= ./out/
+BUILD_OUTPUT_FILE ?= operator
 VENDOR_BUILD ?= 
 
 .PHONY: build
 ## Build the operator
 build: ./out/operator
+
+.PHONY: build-all
+## Build the operator and compress all manifests
+build-all: ./out/operator ./out/build/bin manifests
 
 .PHONY: clean
 clean:
@@ -38,7 +42,7 @@ clean:
 	#$(Q)operator-sdk generate k8s
 	$(Q)go version
 	$(Q)CGO_ENABLED=0 GOARCH=amd64 GOOS=linux \
-		go build ${V_FLAG} ${VENDOR_BUILD} -o ${BUILD_DIR}${BUILD_OUT_FILE} \
+		go build ${V_FLAG} ${VENDOR_BUILD} -o ${BUILD_OUTPUT_DIR}${BUILD_OUTPUT_FILE} \
 		./cmd/manager
 
 ./out/build/bin:


### PR DESCRIPTION
Productization build requires vendored build and different
build output path.
This patch adds additional target for the same.