### PR TITLE
Add mechanism to update TektonVersion flag for nightly

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -46,6 +46,7 @@ for d in $(ls ${PAYLOAD_ROOT}/${LATEST_RELEASE}); do
 done
 
 git add deploy/resources
+git add  pkg/flag/flag.go
 git commit -m ":Add payload: pipelines,clustertasks,triggers,consolesampleyamls"
 git push -f openshift release-next
 


### PR DESCRIPTION
Add a `sed` step in openshift/release/fetch-pipeline.sh to
update `TektonVersion` variable in flag package.
(eg: TektonVersion="release-next")
So that the right payload is used to run tests.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>