### PR TITLE
Simplify nightly test payaload fetch mechanism

### DIFF
--- a/openshift/release/fetch-pipeline.sh
+++ b/openshift/release/fetch-pipeline.sh
@@ -25,37 +25,23 @@ function tryurl {
 }
 
 function geturl() {
-    if [[ ${1} = "release-next" ]];then
-         if tryurl ${NIGHTLY_RELEASE};then
-             echo ${NIGHTLY_RELEASE}
-             return 0
-         fi
-        for shifted in `seq 0 ${MAX_SHIFT}`;do
-            versionyaml=$(get_version ${shifted})
-            if tryurl ${versionyaml};then
-                echo ${versionyaml}
-                return 0
-            fi
-        done
-    else
-        local version=${1}
-        PAYLOAD_PIPELINE_VERSION=${1}
-        versionyaml=$(eval echo ${STABLE_RELEASE_URL})
-        echo ${versionyaml}
-        return 0
+    if tryurl ${NIGHTLY_RELEASE};then
+         echo ${NIGHTLY_RELEASE}
+         return 0
     fi
-
+    for shifted in `seq 0 ${MAX_SHIFT}`;do
+        versionyaml=$(get_version ${shifted})
+        if tryurl ${versionyaml};then
+            echo ${versionyaml}
+            return 0
+        fi
+    done
     echo \n"No working Pipeline payload url found"\n
     exit 1
 }
 
-URL=$(geturl $1)
+URL=$(geturl)
 echo Pipeline Payload URL: ${URL}
 
-[[ -d ${2}/pipelines ]] || mkdir -p ${2}/pipelines
-curl -Ls ${URL} -o ${2}/pipelines/release.yaml
-
-PROJECT_ROOT=${2}/../../..
-
-sed -i 's/^[[:space:]]*TektonVersion.*/TektonVersion = "'${PAYLOAD_PIPELINE_VERSION}'"/' ${PROJECT_ROOT}/pkg/flag/flag.go
-go fmt ${PROJECT_ROOT}/pkg/flag/flag.go
+[[ -d ${1}/pipelines ]] || mkdir -p ${1}/pipelines
+curl -Ls ${URL} -o ${1}/pipelines/release.yaml

--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -4,12 +4,8 @@
 # Usage: update-to-head.sh
 
 set -e
-VERSION=$1
 BRANCH_NAME=release-next
-if [[ -n $VERSION ]]; then
-  BRANCH_NAME=release-${VERSION}
-fi
-VERSION=${VERSION:-release-next}
+VERSION=release-next
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 REPO_NAME=`basename ${PROJECT_ROOT}`
@@ -28,7 +24,10 @@ PAYLOAD_PATH=${PAYLOAD_ROOT}/${VERSION}
 mkdir -p ${PAYLOAD_PATH}
 
 #get pipeline manifest
-${PROJECT_ROOT}/openshift/release/fetch-pipeline.sh ${VERSION} ${PAYLOAD_PATH}
+${PROJECT_ROOT}/openshift/release/fetch-pipeline.sh ${PAYLOAD_PATH}
+
+sed -i 's/^[[:space:]]*TektonVersion.*/TektonVersion = "'${VERSION}'"/' ${PROJECT_ROOT}/pkg/flag/flag.go
+go fmt ${PROJECT_ROOT}/pkg/flag/flag.go
 
 # copy rest of the payload from the previous release
 # TODO get triggers from nightly or latest release


### PR DESCRIPTION
This patch is the first part of simplifying
collecting payload (pipeline, triggers, clustertasks etc)

This patch reduces the scope of

    - openshift/release/fetch-pipeline.sh
    - openshift/release/update-to-head.sh

to nightly tests payload fetching

Separate scripts, make targets, documentation will be added for
creating versioned releases (branching, payload fetching ...)

This change is necessary because the operator's dependencies are not
only pipelines but also other items like triggers, clustertasks, consoleyamlsamples ...
each with its own releases (nightly/versioned)

Hence, trying to manage both nightly builds and versioned releases for operator using the
same set of scripts lead to complications. So it is better handle them in separate scripts.

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>