### PR TITLE
Keep yamllint rules same across projects

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,3 +1,7 @@
+ignore: |
+  /vendor
+  test/**/*-chart/**
+
 rules:
   braces: enable
   brackets: enable
@@ -10,13 +14,11 @@ rules:
   document-end: disable
   document-start: disable
   empty-lines: enable
-  empty-values:
-    level: warning
+  empty-values: enable
   hyphens: enable
   key-duplicates: enable
   key-ordering: disable
-  line-length:
-    level: warning
+  line-length: disable
   new-line-at-end-of-file: disable
   new-lines: enable
   octal-values: enable

--- a/deploy/resources/v0.5.2/release.yaml
+++ b/deploy/resources/v0.5.2/release.yaml
@@ -186,16 +186,16 @@ kind: ConfigMap
 metadata:
   name: config-artifact-bucket
   namespace: tekton-pipelines
-data:
-# location of the gcs bucket to be used for artifact storage
-# location: "gs://bucket-name"
-
-# name of the secret that will contain the credentials for the service account
-# with access to the bucket
-# bucket.service.account.secret.name:
-
-# The key in the secret with the required service account json
-# bucket.service.account.secret.key:
+#  data:
+#  # location of the gcs bucket to be used for artifact storage
+#  location: "gs://bucket-name"
+#
+#  # name of the secret that will contain the credentials for the service account
+#  # with access to the bucket
+#  bucket.service.account.secret.name:
+#
+#  # The key in the secret with the required service account json
+#  bucket.service.account.secret.key:
 
 
 ---
@@ -218,9 +218,9 @@ kind: ConfigMap
 metadata:
   name: config-artifact-pvc
   namespace: tekton-pipelines
-data:
-# size of the PVC volume
-# size: 5Gi
+# data:
+#   # size of the PVC volume
+#   size: 5Gi
 
 ---
 kind: ClusterRole

--- a/deploy/resources/v0.7.0/release.yaml
+++ b/deploy/resources/v0.7.0/release.yaml
@@ -570,16 +570,16 @@ kind: ConfigMap
 metadata:
   name: config-artifact-bucket
   namespace: tekton-pipelines
-data:
-  # location of the gcs bucket to be used for artifact storage
-  # location: "gs://bucket-name"
-
-  # name of the secret that will contain the credentials for the service account
-  # with access to the bucket
-  # bucket.service.account.secret.name:
-
-  # The key in the secret with the required service account json
-  # bucket.service.account.secret.key:
+# data:
+#   # location of the gcs bucket to be used for artifact storage
+#   location: "gs://bucket-name"
+#
+#   # name of the secret that will contain the credentials for the service account
+#   # with access to the bucket
+#   bucket.service.account.secret.name:
+#
+#   # The key in the secret with the required service account json
+#   bucket.service.account.secret.key:
 
 
 ---
@@ -602,12 +602,12 @@ kind: ConfigMap
 metadata:
   name: config-artifact-pvc
   namespace: tekton-pipelines
-data:
-  # size of the PVC volume
-  # size: 5Gi
-
-  # storage class of the PVC volume
-  # storageClassName: storage-class-name
+# data:
+#   # size of the PVC volume
+#   size: 5Gi
+#
+#   # storage class of the PVC volume
+#   storageClassName: storage-class-name
 ---
 # Copyright 2019 The Tekton Authors
 #

--- a/deploy/resources/v0.8.0/addons/clustertasks/cluster-role.yaml
+++ b/deploy/resources/v0.8.0/addons/clustertasks/cluster-role.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: tekton-clustertasks-view

--- a/deploy/resources/v0.8.0/pipelines/release.yaml
+++ b/deploy/resources/v0.8.0/pipelines/release.yaml
@@ -570,16 +570,16 @@ kind: ConfigMap
 metadata:
   name: config-artifact-bucket
   namespace: tekton-pipelines
-data:
-  # location of the gcs bucket to be used for artifact storage
-  # location: "gs://bucket-name"
-
-  # name of the secret that will contain the credentials for the service account
-  # with access to the bucket
-  # bucket.service.account.secret.name:
-
-  # The key in the secret with the required service account json
-  # bucket.service.account.secret.key:
+# data:
+#   # location of the gcs bucket to be used for artifact storage
+#   location: "gs://bucket-name"
+#
+#   # name of the secret that will contain the credentials for the service account
+#   # with access to the bucket
+#   bucket.service.account.secret.name:
+#
+#   # The key in the secret with the required service account json
+#   bucket.service.account.secret.key:
 
 
 ---
@@ -602,12 +602,12 @@ kind: ConfigMap
 metadata:
   name: config-artifact-pvc
   namespace: tekton-pipelines
-data:
-  # size of the PVC volume
-  # size: 5Gi
-
-  # storage class of the PVC volume
-  # storageClassName: storage-class-name
+# data:
+#   # size of the PVC volume
+#   size: 5Gi
+#
+#   # storage class of the PVC volume
+#   storageClassName: storage-class-name
 ---
 # Copyright 2019 The Tekton Authors
 #

--- a/deploy/resources/v0.9.2/addons/clustertasks/cluster-role.yaml
+++ b/deploy/resources/v0.9.2/addons/clustertasks/cluster-role.yaml
@@ -1,7 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  annotations:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: tekton-clustertasks-view


### PR DESCRIPTION
Previously operator used a yamllint that is different to other upstream
projects. This meant that yaml files generated in upstream project may
fail in operator's CI. This is fixed by moving the to same `.yamllint`
files.

Signed-off-by: Sunil Thaha <sthaha@redhat.com>