### PR TITLE
Add go and java pipeline for +Add flows

### DIFF
--- a/deploy/resources/v0.9.2/addons/pipelines/s2i-go/s2i-go-build-deploy.yaml
+++ b/deploy/resources/v0.9.2/addons/pipelines/s2i-go/s2i-go-build-deploy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: s2i-go
+  namespace: openshift
+  labels:
+    pipeline.openshift.io/runtime: golang
+  annotations:
+    operator.tekton.dev/preserve-namespace: "true"
+spec:
+  params:
+    - name: IMAGE_NAME
+      type: string
+  resources:
+    - name: app-source
+      type: git
+    - name: app-image
+      type: image
+
+  tasks:
+    - name: build
+      taskRef:
+        name: s2i-go
+        kind: ClusterTask
+      resources:
+        inputs:
+          - name: source
+            resource: app-source
+        outputs:
+          - name: image
+            resource: app-image
+      params:
+        - name: TLSVERIFY
+          value: "false"
+
+    - name: deploy
+      taskRef:
+        name: openshift-client
+        kind: ClusterTask
+      params:
+        - name: ARGS
+          value: ["new-app", "--docker-image", "$(params.IMAGE_NAME)"]

--- a/deploy/resources/v0.9.2/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml
+++ b/deploy/resources/v0.9.2/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: s2i-java-11
+  namespace: openshift
+  labels:
+    pipeline.openshift.io/runtime: java
+  annotations:
+    operator.tekton.dev/preserve-namespace: "true"
+spec:
+  params:
+    - name: IMAGE_NAME
+      type: string
+  resources:
+    - name: app-source
+      type: git
+    - name: app-image
+      type: image
+
+  tasks:
+    - name: build
+      taskRef:
+        name: s2i-java-11
+        kind: ClusterTask
+      resources:
+        inputs:
+          - name: source
+            resource: app-source
+        outputs:
+          - name: image
+            resource: app-image
+      params:
+        - name: TLSVERIFY
+          value: "false"
+
+    - name: deploy
+      taskRef:
+        name: openshift-client
+        kind: ClusterTask
+      params:
+        - name: ARGS
+          value: ["new-app", "--docker-image", "$(params.IMAGE_NAME)"]

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -322,7 +322,7 @@ func (r *ReconcileConfig) applyAddons(req reconcile.Request, cfg *op.Config) (re
 func transformManifest(cfg *op.Config, m *mf.Manifest) error {
 	tfs := []mf.Transformer{
 		mf.InjectOwner(cfg),
-		mf.InjectNamespace(cfg.Spec.TargetNamespace),
+		transform.InjectNamespaceConditional(flag.AnnotationPreserveNS, cfg.Spec.TargetNamespace),
 		transform.InjectDefaultSA(flag.DefaultSA),
 	}
 	return m.Transform(tfs...)

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -28,6 +28,8 @@ const (
 	TriggerControllerName = "tekton-triggers-controller"
 	TriggerWebhookName    = "tekton-triggers-webhook"
 
+	AnnotationPreserveNS = "operator.tekton.dev/preserve-namespace"
+
 	uuidPath = "deploy/uuid"
 )
 

--- a/pkg/utils/transform/transform.go
+++ b/pkg/utils/transform/transform.go
@@ -35,3 +35,16 @@ func InjectDefaultSA(defaultSA string) mf.Transformer {
 		return nil
 	}
 }
+
+func InjectNamespaceConditional(preserveNamespace string, targetNamespace string) mf.Transformer {
+	tf := mf.InjectNamespace(targetNamespace)
+	return func(u *unstructured.Unstructured) error {
+		annotations := u.GetAnnotations()
+		val, ok := annotations[preserveNamespace]
+		if ok && val == "true" {
+			return nil
+		}
+
+		return tf(u)
+	}
+}


### PR DESCRIPTION
This adds pipelines for go and java based source.
Pipeline consist of build and deploy tasks
required for +Add flows in console

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>