### PR TITLE
Adds runAfter to pipeline templates

### DIFF
--- a/deploy/resources/v0.9.2/addons/pipelines/s2i-go/s2i-go-build-deploy.yaml
+++ b/deploy/resources/v0.9.2/addons/pipelines/s2i-go/s2i-go-build-deploy.yaml
@@ -38,6 +38,8 @@ spec:
       taskRef:
         name: openshift-client
         kind: ClusterTask
+      runAfter:
+        - build
       params:
         - name: ARGS
           value: ["new-app", "--docker-image", "$(params.IMAGE_NAME)"]

--- a/deploy/resources/v0.9.2/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml
+++ b/deploy/resources/v0.9.2/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml
@@ -38,6 +38,8 @@ spec:
       taskRef:
         name: openshift-client
         kind: ClusterTask
+      runAfter:
+        - build
       params:
         - name: ARGS
           value: ["new-app", "--docker-image", "$(params.IMAGE_NAME)"]


### PR DESCRIPTION
This add a runAfter in deploy step, which makes deploy step only
run after build is done.

Signed-off-by: Pradeep Kumar pradkuma@redhat.com