### PR TITLE
Add mechanism install non-Red-Hat-supported Tasks

### DIFF
--- a/pkg/apis/operator/v1alpha1/config_types.go
+++ b/pkg/apis/operator/v1alpha1/config_types.go
@@ -74,9 +74,18 @@ const (
 	// Check details field for additional details
 	InvalidResource InstallStatus = "invalid-resource"
 
+	// AppliedAddons indicates that the pipeline addons
+	// have been applied on the cluster
+	AppliedAddons InstallStatus = "applied-addons"
+
 	// AddonsError indicates that there was an error installing addons
 	// Check details field for additional details
 	AddonsError InstallStatus = "error-addons"
+
+	// NonRedHatResourcesError indicates that there was an error
+	// installing non Red Hat Resources
+	// Check details field for additional details
+	NonRedHatResourcesError InstallStatus = "error-non-redhat-resources"
 
 	// InstalledStatus indicates that all pipeline resources are installed successfully
 	InstalledStatus InstallStatus = "installed"

--- a/pkg/apis/operator/v1alpha1/config_types.go
+++ b/pkg/apis/operator/v1alpha1/config_types.go
@@ -82,10 +82,10 @@ const (
 	// Check details field for additional details
 	AddonsError InstallStatus = "error-addons"
 
-	// NonRedHatResourcesError indicates that there was an error
-	// installing non Red Hat Resources
+	// CommunityResourcesError indicates that there was an error
+	// installing Community Provided Resources
 	// Check details field for additional details
-	NonRedHatResourcesError InstallStatus = "error-non-redhat-resources"
+	CommunityResourcesError InstallStatus = "error-community-resources"
 
 	// InstalledStatus indicates that all pipeline resources are installed successfully
 	InstalledStatus InstallStatus = "installed"

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -320,10 +320,8 @@ func (r *ReconcileConfig) applyAddons(req reconcile.Request, cfg *op.Config) (re
 	log := requestLogger(req, "apply-addons")
 
 	//add TaskProviderType label to ClusterTasks (community, redhat, certified)
-	addnTfrms := []mf.Transformer{
-		transform.InjectLabel(flag.LabelTaskProviderType, flag.TaskProviderTypeRedHat, true, "ClusterTask"),
-	}
-	if err := transformManifest(cfg, &r.addons, addnTfrms...); err != nil {
+	injectLabel := transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeRedHat, true, "ClusterTask")
+	if err := transformManifest(cfg, &r.addons, injectLabel); err != nil {
 		log.Error(err, "failed to apply manifest transformations on pipeline-addons")
 		// ignoring failure to update
 		_ = r.updateStatus(cfg, op.ConfigCondition{
@@ -355,7 +353,7 @@ func (r *ReconcileConfig) applyNonRedHatResources(req reconcile.Request, cfg *op
 	addnTfrms := []mf.Transformer{
 		// replace kind: Task, with kind: ClusterTask
 		transform.ReplaceKind("Task", "ClusterTask"),
-		transform.InjectLabel(flag.LabelTaskProviderType, flag.TaskProviderTypeCommunity, true),
+		transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeCommunity, true),
 	}
 	if err := transformManifest(cfg, &r.nonRedHatResources, addnTfrms...); err != nil {
 		log.Error(err, "failed to apply manifest transformations on pipeline-addons")

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -320,7 +320,7 @@ func (r *ReconcileConfig) applyAddons(req reconcile.Request, cfg *op.Config) (re
 	log := requestLogger(req, "apply-addons")
 
 	//add TaskProviderType label to ClusterTasks (community, redhat, certified)
-	injectLabel := transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeRedHat, true, "ClusterTask")
+	injectLabel := transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeRedHat, transform.Overwrite, "ClusterTask")
 	if err := transformManifest(cfg, &r.addons, injectLabel); err != nil {
 		log.Error(err, "failed to apply manifest transformations on pipeline-addons")
 		// ignoring failure to update
@@ -353,7 +353,7 @@ func (r *ReconcileConfig) applyNonRedHatResources(req reconcile.Request, cfg *op
 	addnTfrms := []mf.Transformer{
 		// replace kind: Task, with kind: ClusterTask
 		transform.ReplaceKind("Task", "ClusterTask"),
-		transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeCommunity, true),
+		transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeCommunity, transform.Overwrite),
 	}
 	if err := transformManifest(cfg, &r.nonRedHatResources, addnTfrms...); err != nil {
 		log.Error(err, "failed to apply manifest transformations on pipeline-addons")

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -67,10 +67,10 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 		return nil, err
 	}
 
-	nonRedHat, err := fetchNonRedHat(mgr)
+	community, err := fetchCommuntiyResources(mgr)
 	if err != nil {
 		log.Error(err, "error fetching community resources")
-		nonRedHat = mf.Manifest{}
+		community = mf.Manifest{}
 	}
 
 	secClient, err := sec.NewForConfig(mgr.GetConfig())
@@ -79,27 +79,27 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 	}
 
 	return &ReconcileConfig{
-		client:             mgr.GetClient(),
-		scheme:             mgr.GetScheme(),
-		secClient:          secClient,
-		pipeline:           pipeline,
-		addons:             addons,
-		nonRedHatResources: nonRedHat,
+		client:    mgr.GetClient(),
+		scheme:    mgr.GetScheme(),
+		secClient: secClient,
+		pipeline:  pipeline,
+		addons:    addons,
+		community: community,
 	}, nil
 }
 
-func fetchNonRedHat(mgr manager.Manager) (mf.Manifest, error) {
+func fetchCommuntiyResources(mgr manager.Manager) (mf.Manifest, error) {
 	if flag.SkipNonRedHatResources {
 		return mf.Manifest{}, nil
 	}
 	//manifestival can take urls/filepaths as input
 	//more that one items can be passed as a comma separated list string
-	urls := strings.Join(flag.NonRedHatResourceURLs, ",")
-	nonRedHat, err := mf.NewManifest(urls, flag.Recursive, mgr.GetClient())
+	urls := strings.Join(flag.CommunityResourceURLs, ",")
+	community, err := mf.NewManifest(urls, flag.Recursive, mgr.GetClient())
 	if err != nil {
 		return mf.Manifest{}, err
 	}
-	return nonRedHat, nil
+	return community, nil
 }
 
 // this will read all the addons files
@@ -188,12 +188,12 @@ var _ reconcile.Reconciler = &ReconcileConfig{}
 type ReconcileConfig struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client             client.Client
-	secClient          *sec.SecurityV1Client
-	scheme             *runtime.Scheme
-	pipeline           mf.Manifest
-	addons             mf.Manifest
-	nonRedHatResources mf.Manifest
+	client    client.Client
+	secClient *sec.SecurityV1Client
+	scheme    *runtime.Scheme
+	pipeline  mf.Manifest
+	addons    mf.Manifest
+	community mf.Manifest
 }
 
 // Reconcile reads that state of the cluster for a Config object and makes changes based on the state read
@@ -241,8 +241,8 @@ func (r *ReconcileConfig) Reconcile(req reconcile.Request) (reconcile.Result, er
 		return r.validatePipeline(req, cfg)
 	case op.ValidatedPipeline, op.AddonsError:
 		return r.applyAddons(req, cfg)
-	case op.AppliedAddons, op.NonRedHatResourcesError:
-		return r.applyNonRedHatResources(req, cfg)
+	case op.AppliedAddons, op.CommunityResourcesError:
+		return r.applyCommunityResources(req, cfg)
 	case op.InstalledStatus:
 		return r.validateVersion(req, cfg)
 	}
@@ -346,7 +346,7 @@ func (r *ReconcileConfig) applyAddons(req reconcile.Request, cfg *op.Config) (re
 	return reconcile.Result{Requeue: true}, err
 }
 
-func (r *ReconcileConfig) applyNonRedHatResources(req reconcile.Request, cfg *op.Config) (reconcile.Result, error) {
+func (r *ReconcileConfig) applyCommunityResources(req reconcile.Request, cfg *op.Config) (reconcile.Result, error) {
 	log := requestLogger(req, "apply-non-redhat-resources")
 
 	//add TaskProviderType label to ClusterTasks (community, redhat, certified)
@@ -355,21 +355,21 @@ func (r *ReconcileConfig) applyNonRedHatResources(req reconcile.Request, cfg *op
 		transform.ReplaceKind("Task", "ClusterTask"),
 		transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeCommunity, transform.Overwrite),
 	}
-	if err := transformManifest(cfg, &r.nonRedHatResources, addnTfrms...); err != nil {
+	if err := transformManifest(cfg, &r.community, addnTfrms...); err != nil {
 		log.Error(err, "failed to apply manifest transformations on pipeline-addons")
 		// ignoring failure to update
 		_ = r.updateStatus(cfg, op.ConfigCondition{
-			Code:    op.NonRedHatResourcesError,
+			Code:    op.CommunityResourcesError,
 			Details: err.Error(),
 			Version: flag.TektonVersion})
 		return reconcile.Result{}, err
 	}
 
-	if err := r.nonRedHatResources.ApplyAll(); err != nil {
+	if err := r.community.ApplyAll(); err != nil {
 		log.Error(err, "failed to apply non Red Hat resources yaml manifest")
 		// ignoring failure to update
 		_ = r.updateStatus(cfg, op.ConfigCondition{
-			Code:    op.NonRedHatResourcesError,
+			Code:    op.CommunityResourcesError,
 			Details: err.Error(),
 			Version: flag.TektonVersion})
 		return reconcile.Result{}, err

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -28,7 +28,11 @@ const (
 	TriggerControllerName = "tekton-triggers-controller"
 	TriggerWebhookName    = "tekton-triggers-webhook"
 
-	AnnotationPreserveNS = "operator.tekton.dev/preserve-namespace"
+	AnnotationPreserveNS      = "operator.tekton.dev/preserve-namespace"
+	LabelTaskProviderType     = "operator.tekton.dev/provider-type"
+	TaskProviderTypeCommunity = "community"
+	TaskProviderTypeRedHat    = "redhat"
+	TaskProviderTypeCertified = "certified"
 
 	uuidPath = "deploy/uuid"
 )

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -28,11 +28,11 @@ const (
 	TriggerControllerName = "tekton-triggers-controller"
 	TriggerWebhookName    = "tekton-triggers-webhook"
 
-	AnnotationPreserveNS      = "operator.tekton.dev/preserve-namespace"
-	LabelTaskProviderType     = "operator.tekton.dev/provider-type"
-	TaskProviderTypeCommunity = "community"
-	TaskProviderTypeRedHat    = "redhat"
-	TaskProviderTypeCertified = "certified"
+	AnnotationPreserveNS  = "operator.tekton.dev/preserve-namespace"
+	LabelProviderType     = "operator.tekton.dev/provider-type"
+	ProviderTypeCommunity = "community"
+	ProviderTypeRedHat    = "redhat"
+	ProviderTypeCertified = "certified"
 
 	uuidPath = "deploy/uuid"
 )

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -37,14 +37,21 @@ var (
 	flagSet *pflag.FlagSet
 
 	TektonVersion   = "v0.10.1"
-	PipelineSA      string
-	IgnorePattern   string
-	ResourceWatched string
-	ResourceDir     string
-	TargetNamespace string
-	NoAutoInstall   bool
-	Recursive       bool
-	OperatorUUID    string
+	PipelineSA             string
+	IgnorePattern          string
+	ResourceWatched        string
+	ResourceDir            string
+	TargetNamespace        string
+	NoAutoInstall          bool
+	SkipNonRedHatResources bool
+	Recursive              bool
+	OperatorUUID           string
+	NonRedHatResourceURLs  = []string{
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/jib-maven/jib-maven.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/maven/maven.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/tkn/tkn.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/kn/kn.yaml",
+	}
 )
 
 func init() {
@@ -80,10 +87,13 @@ func init() {
 		"Do not automatically install tekton pipelines, default: false")
 
 	flagSet.BoolVar(
-		&Recursive, "recursive", false,
+		&SkipNonRedHatResources, "skip-non-redhat", false,
+		"If enabled skip adding Tasks/Pipelines not supported/owned by Red Hat")
+
+	flagSet.BoolVar(
+		&Recursive, "recursive", true,
 		"If enabled apply manifest file in resource directory recursively")
 }
-
 func FlagSet() *pflag.FlagSet {
 	return flagSet
 }

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -50,7 +50,7 @@ var (
 	SkipNonRedHatResources bool
 	Recursive              bool
 	OperatorUUID           string
-	NonRedHatResourceURLs  = []string{
+	CommunityResourceURLs  = []string{
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/jib-maven/jib-maven.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/maven/maven.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/tkn/tkn.yaml",

--- a/pkg/utils/transform/testdata/test-inject-label-kind-set.yaml
+++ b/pkg/utils/transform/testdata/test-inject-label-kind-set.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    operator.tekton.dev/provider-type: community
+spec:
+  containers:
+  - name: busy
+    image: busybox
+---
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: echo-hello-world
+spec:
+  steps:
+  - name: echo
+    image: ubuntu
+    command:
+    - echo
+    args:
+    - "hello world"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376

--- a/pkg/utils/transform/testdata/test-inject-label-overwrite.yaml
+++ b/pkg/utils/transform/testdata/test-inject-label-overwrite.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  labels:
+    operator.tekton.dev/provider-type: redhat
+spec:
+  containers:
+  - name: busy
+    image: busybox

--- a/pkg/utils/transform/testdata/test-inject-label.yaml
+++ b/pkg/utils/transform/testdata/test-inject-label.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+spec:
+  containers:
+  - name: busy
+    image: busybox

--- a/pkg/utils/transform/testdata/test-replace-kind.yaml
+++ b/pkg/utils/transform/testdata/test-replace-kind.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1alpha1
+kind: Task
+metadata:
+  name: echo-hello-world
+spec:
+  steps:
+  - name: echo
+    image: ubuntu
+    command:
+    - echo
+    args:
+    - "hello world"

--- a/pkg/utils/transform/transform.go
+++ b/pkg/utils/transform/transform.go
@@ -59,7 +59,13 @@ func ReplaceKind(fromKind, toKind string) mf.Transformer {
 		}
 		err := unstructured.SetNestedField(u.Object, toKind, "kind")
 		if err != nil {
-			return fmt.Errorf("could change resource KIND, %q", err)
+			return fmt.Errorf(
+				"failed to change resource Name:%s, KIND from %s to %s, %s",
+				u.GetName(),
+				fromKind,
+				toKind,
+				err,
+			)
 		}
 		return nil
 	}
@@ -71,7 +77,7 @@ func InjectLabel(key, value string, overwrite bool, kinds ...string) mf.Transfor
 		if len(kinds) != 0 && !itemInSlice(kind, kinds) {
 			return nil
 		}
-		labels, found, err := unstructured.NestedMap(u.Object, "metadata", "labels")
+		labels, found, err := unstructured.NestedStringMap(u.Object, "metadata", "labels")
 		if err != nil {
 			return fmt.Errorf("could not find labels set, %q", err)
 		}
@@ -80,13 +86,13 @@ func InjectLabel(key, value string, overwrite bool, kinds ...string) mf.Transfor
 				return nil
 			}
 		}
-		if !found || labels == nil {
-			labels = map[string]interface{}{}
+		if !found {
+			labels = map[string]string{}
 		}
 		labels[key] = value
-		err = unstructured.SetNestedMap(u.Object, labels, "metadata", "labels")
+		err = unstructured.SetNestedStringMap(u.Object, labels, "metadata", "labels")
 		if err != nil {
-			return fmt.Errorf("error updateing labes for %v:%v, %v", kind, u.GetName(), err)
+			return fmt.Errorf("error updateing labes for %s:%s, %s", kind, u.GetName(), err)
 		}
 		return nil
 	}

--- a/pkg/utils/transform/transform.go
+++ b/pkg/utils/transform/transform.go
@@ -85,7 +85,7 @@ func ReplaceKind(fromKind, toKind string) mf.Transformer {
 func InjectLabel(key, value string, overwritePolicy OverwritePolicy, kinds ...string) mf.Transformer {
 	return func(u *unstructured.Unstructured) error {
 		kind := u.GetKind()
-		if len(kinds) != 0 && !itemInSlice(kind, kinds) {
+		if len(kinds) != 0 && !ItemInSlice(kind, kinds) {
 			return nil
 		}
 		labels, found, err := unstructured.NestedStringMap(u.Object, "metadata", "labels")
@@ -109,7 +109,7 @@ func InjectLabel(key, value string, overwritePolicy OverwritePolicy, kinds ...st
 	}
 }
 
-func itemInSlice(item string, items []string) bool {
+func ItemInSlice(item string, items []string) bool {
 	for _, v := range items {
 		if v == item {
 			return true

--- a/pkg/utils/transform/transform_test.go
+++ b/pkg/utils/transform/transform_test.go
@@ -1,8 +1,11 @@
-package transform
+package transform_test
 
 import (
-	"github.com/tektoncd/operator/pkg/flag"
+	"path"
 	"testing"
+
+	"github.com/tektoncd/operator/pkg/flag"
+	"github.com/tektoncd/operator/pkg/utils/transform"
 
 	mf "github.com/jcrossley3/manifestival"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -11,37 +14,107 @@ import (
 func TestTransformManifest_WithAnnotation(t *testing.T) {
 	resourceWithAnnotation := "testdata/with-annotation.yaml"
 	manifest, err := mf.NewManifest(resourceWithAnnotation, true, nil)
-	if err != nil {
-		t.Errorf("NewManifest() = %v, wanted no error", err)
-	}
-
-	tfs := []mf.Transformer{
-		InjectNamespaceConditional(flag.AnnotationPreserveNS, "target"),
-	}
-
-	if err := manifest.Transform(tfs...); err != nil {
-		t.Error("wanted no error :", err)
-	}
-
+	assetNoEror(t, err)
+	tf := transform.InjectNamespaceConditional(flag.AnnotationPreserveNS, "target")
+	err = manifest.Transform(tf)
+	assetNoEror(t, err)
 	assertNamespace(t, manifest.Resources[0], "openshift")
 }
 
 func TestTransformManifest_WithoutAnnotation(t *testing.T) {
 	resourceWithoutAnnotation := "testdata/without-annotation.yaml"
 	manifest, err := mf.NewManifest(resourceWithoutAnnotation, true, nil)
-	if err != nil {
-		t.Errorf("NewManifest() = %v, wanted no error", err)
-	}
-
-	tfs := []mf.Transformer{
-		InjectNamespaceConditional(flag.AnnotationPreserveNS, "target"),
-	}
-
-	if err := manifest.Transform(tfs...); err != nil {
-		t.Error("expected no error :", err)
-	}
-
+	assetNoEror(t, err)
+	tf := transform.InjectNamespaceConditional(flag.AnnotationPreserveNS, "target")
+	err = manifest.Transform(tf)
+	assetNoEror(t, err)
 	assertNamespace(t, manifest.Resources[0], "target")
+}
+
+func TestReplaceKind(t *testing.T) {
+	fromKind := "Task"
+	fromKindMismatch := "Pod"
+	toKind := "ClusterTask"
+	testData := path.Join("testdata", "test-replace-kind.yaml")
+
+	t.Run("should replace Kind when resource kind == fromKind", func(t *testing.T) {
+		manifest, err := mf.NewManifest(testData, true, nil)
+		assetNoEror(t, err)
+		replaceKind := transform.ReplaceKind(fromKind, toKind)
+		err = manifest.Transform(replaceKind)
+		assetNoEror(t, err)
+		assertKind(t, manifest.Resources[0], toKind)
+	})
+	t.Run("should not replace Kind when resource kind != fromKind", func(t *testing.T) {
+		manifest, err := mf.NewManifest(testData, true, nil)
+		assetNoEror(t, err)
+		replaceKind := transform.ReplaceKind(fromKindMismatch, toKind)
+		err = manifest.Transform(replaceKind)
+		assetNoEror(t, err)
+		assertKind(t, manifest.Resources[0], fromKind)
+	})
+}
+
+func TestInjectLabel(t *testing.T) {
+	key := flag.LabelProviderType
+	value := flag.ProviderTypeCommunity
+
+	t.Run("should add label to a resource", func(t *testing.T) {
+		testData := path.Join("testdata", "test-inject-label.yaml")
+
+		manifest, err := mf.NewManifest(testData, true, nil)
+		assetNoEror(t, err)
+		injectLabel := transform.InjectLabel(key, value, transform.Overwrite)
+		err = manifest.Transform(injectLabel)
+		assetNoEror(t, err)
+		assertLabel(t, manifest.Resources[0], key, value)
+	})
+	t.Run("should add label if kind(s) is specified and does not match resource kind", func(t *testing.T) {
+		testData := path.Join("testdata", "test-inject-label.yaml")
+
+		manifest, err := mf.NewManifest(testData, true, nil)
+		assetNoEror(t, err)
+		injectLabel := transform.InjectLabel(key, value, transform.Overwrite, "Service")
+		err = manifest.Transform(injectLabel)
+		assetNoEror(t, err)
+		assertNoLabel(t, manifest.Resources[0], key, value)
+	})
+
+	t.Run("should retain original label with overwritePolicy 'Retain'", func(t *testing.T) {
+		existingValue := flag.ProviderTypeRedHat
+		testData := path.Join("testdata", "test-inject-label-overwrite.yaml")
+
+		manifest, err := mf.NewManifest(testData, true, nil)
+		assetNoEror(t, err)
+		injectLabel := transform.InjectLabel(key, value, transform.Retain)
+		err = manifest.Transform(injectLabel)
+		assetNoEror(t, err)
+		assertLabel(t, manifest.Resources[0], key, existingValue)
+	})
+	t.Run("should overwrite original label with overwritePolicy 'Overwrite'", func(t *testing.T) {
+		testData := path.Join("testdata", "test-inject-label-overwrite.yaml")
+
+		manifest, err := mf.NewManifest(testData, true, nil)
+		assetNoEror(t, err)
+		injectLabel := transform.InjectLabel(key, value, transform.Overwrite)
+		err = manifest.Transform(injectLabel)
+		assetNoEror(t, err)
+		assertLabel(t, manifest.Resources[0], key, value)
+	})
+	t.Run("should add labels only to specified resources", func(t *testing.T) {
+		testData := path.Join("testdata", "test-inject-label-kind-set.yaml")
+		kinds := []string{
+			"Pod",
+			"Service",
+		}
+
+		manifest, err := mf.NewManifest(testData, true, nil)
+		assetNoEror(t, err)
+		injectLabel := transform.InjectLabel(key, value, transform.Overwrite, kinds...)
+		err = manifest.Transform(injectLabel)
+		assetNoEror(t, err)
+		assertOnResourceList(t, manifest.Resources, key, value, kinds...)
+	})
 }
 
 func assertNamespace(t *testing.T, u unstructured.Unstructured, expected string) {
@@ -50,5 +123,51 @@ func assertNamespace(t *testing.T, u unstructured.Unstructured, expected string)
 	ns := v["namespace"]
 	if ns != expected {
 		t.Errorf("Expected '%s', got '%s'", expected, ns)
+	}
+}
+
+func assetNoEror(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Errorf("expected no error, %v", err)
+	}
+}
+
+func assertKind(t *testing.T, u unstructured.Unstructured, kind string) {
+	t.Helper()
+	if k := u.GetKind(); k != kind {
+		t.Errorf("expected kind %s, got kind %s", kind, k)
+	}
+}
+
+func assertLabel(t *testing.T, u unstructured.Unstructured, key, value string) {
+	t.Helper()
+	labels, found, err := unstructured.NestedStringMap(u.Object, "metadata", "labels")
+	assetNoEror(t, err)
+	got, ok := labels[key]
+	if !found || !ok || got != value {
+		t.Errorf("expected %s, got %s", value, got)
+	}
+}
+
+func assertNoLabel(t *testing.T, u unstructured.Unstructured, key, value string) {
+	t.Helper()
+	labels, found, err := unstructured.NestedStringMap(u.Object, "metadata", "labels")
+	assetNoEror(t, err)
+	got, ok := labels[key]
+	if found && ok && got == value {
+		t.Errorf("not expected %s, got %s", value, got)
+	}
+}
+
+func assertOnResourceList(t *testing.T, items []unstructured.Unstructured, key, value string, kinds ...string) {
+	t.Helper()
+	for _, item := range items {
+		k := item.GetKind()
+		if transform.ItemInSlice(k, kinds) {
+			assertLabel(t, item, key, value)
+		} else {
+			assertNoLabel(t, item, key, value)
+		}
 	}
 }


### PR DESCRIPTION
Add mechanism to download and install upstream Tasks
not-supported/owned by Red Hat

Add a transform function to convert kind: Task to kind: ClusterTask

Add a mechanism to add label `operator.tekton.dev/provider-type:certified/redhat/community`.

ClusterTasks bundled with operator payload (manifest is in operator repo) are labelled
`operator.tekton.dev/provider-type:redhat`. ClusterTasks downloaded and installed by operator are labelled `operator.tekton.dev/provider-type:community`

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>