### PR TITLE
Fix java pipeline template for image lookup fails

### DIFF
--- a/deploy/resources/v0.10.1/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml
+++ b/deploy/resources/v0.10.1/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml
@@ -10,7 +10,7 @@ metadata:
     operator.tekton.dev/preserve-namespace: "true"
 spec:
   params:
-    - name: IMAGE_NAME
+    - name: APPLICATION_NAME
       type: string
   resources:
     - name: app-source
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["new-app", "--docker-image", "$(params.IMAGE_NAME)"]
+          value: ["rollout", "latest", "$(params.APPLICATION_NAME)"]


### PR DESCRIPTION
Pipeline `deploy` step fails as it tries to deploy new application
deployment config is already created by `console +Add`

Instead deploy step should `rollout` the existing deployment

Signed-off-by: Pradeep Kumar <pradkuma@redhat.com>