### PR TITLE
Changes pipelines image prefix env var and minor code refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@
 Following environment variables allows overriding images of pipelines, trigger and 
 task addons components
 
-1) `IMAGE_PIPELINE_<DEPLOYMENT-IMAGE-NAME>` e.g. `IMAGE_PIPELINE_WEBHOOK`
+1) `IMAGE_PIPELINES_<DEPLOYMENT-IMAGE-NAME>` e.g. `IMAGE_PIPELINES_WEBHOOK`
 It allows overriding pipelines or triggers deployment images. Note, `*_PIPELINE_*` 
-will override images in pipelines manifest only. Same way `*_TRIGGERS_*`
-2) `IMAGE_PIPELINE__ARG_<DEPLOYMENT-IMAGE-ARG-NAME>` e.g. `IMAGE_PIPELINE_ARG_NOP`
+will override images in pipelines manifest only. Same way `IMAGE__TRIGGERS_*`
+2) `IMAGE_PIPELINES__ARG_<DEPLOYMENT-IMAGE-ARG-NAME>` e.g. `IMAGE_PIPELINES_ARG_NOP`
 It allows overriding pipelines or triggers deployment images of containers `args`. 
-Note, `*_PIPELINE_ARG_*` will override images in pipelines manifest only. Same way `**_TRIGGERS_ARG_**`  
+Note, `*_PIPELINE_ARG_*` will override images in pipelines manifest only. Same way `IMAGE__TRIGGERS_ARG_*`  
 3) `IMAGE_ADDONS_<STEP-NAME>` e.g. `IMAGE_ADDONS_PUSH` 
 It allows overriding `ClusterTask` addons steps images.
 4) `IMAGE_ADDONS_PARAM_<NAME>` e.g. `IMAGE_ADDONS_PARAM_BUILDER` 

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -252,7 +252,7 @@ func (r *ReconcileConfig) Reconcile(req reconcile.Request) (reconcile.Result, er
 func (r *ReconcileConfig) applyPipeline(req reconcile.Request, cfg *op.Config) (reconcile.Result, error) {
 	log := requestLogger(req, "apply-pipeline")
 
-	images := transform.ToLowerCaseKeys(imagesFromEnv("IMAGE_PIPELINE_"))
+	images := transform.ToLowerCaseKeys(imagesFromEnv(transform.PipelinesImagePrefix))
 	if err := transformManifest(cfg, &r.pipeline, transform.DeploymentImages(images)); err != nil {
 		log.Error(err, "failed to apply manifest transformations on pipeline-core")
 		// ignoring failure to update
@@ -322,8 +322,8 @@ func (r *ReconcileConfig) applyAddons(req reconcile.Request, cfg *op.Config) (re
 	log := requestLogger(req, "apply-addons")
 
 	//add TaskProviderType label to ClusterTasks (community, redhat, certified)
-	triggerImages := transform.ToLowerCaseKeys(imagesFromEnv("IMAGE_TRIGGERS_"))
-	addonImages := transform.ToLowerCaseKeys(imagesFromEnv("IMAGE_ADDONS_"))
+	triggerImages := transform.ToLowerCaseKeys(imagesFromEnv(transform.TriggersImagePrefix))
+	addonImages := transform.ToLowerCaseKeys(imagesFromEnv(transform.AddonsImagePrefix))
 	addnTfrms := []mf.Transformer{
 		transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeRedHat, transform.Overwrite, "ClusterTask"),
 		transform.DeploymentImages(triggerImages),

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -14,6 +14,7 @@ import (
 	fakesecurityclient "github.com/openshift/client-go/security/clientset/versioned/fake"
 	op "github.com/tektoncd/operator/pkg/apis/operator/v1alpha1"
 	"github.com/tektoncd/operator/pkg/flag"
+	trnsfm "github.com/tektoncd/operator/pkg/utils/transform"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,15 +32,15 @@ func TestConfigControllerReplaceImages(t *testing.T) {
 			configName = "cluster"
 			namespace  = "openshift-pipelines"
 			deployment = "tekton-pipelines-controller"
-			container  = "tekton_triggers_controller"
+			container  = "tekton_pipelines_controller"
 			image      = "registry.redhat.io/osbs/controller:latest"
-			arg        = "shell_image"
+			arg        = "_shell_image"
 			argImage   = "registry.redhat.io/osbs/ubi8:latest"
 		)
 
 		// GIVEN
-		os.Setenv("IMAGE_PIPELINE_"+strings.ToUpper(container), image)
-		os.Setenv("IMAGE_PIPELINE_ARG_"+strings.ToUpper(arg), argImage)
+		os.Setenv(trnsfm.PipelinesImagePrefix+strings.ToUpper(container), image)
+		os.Setenv(trnsfm.PipelinesImagePrefix+trnsfm.ArgPrefix+strings.ToUpper(arg), argImage)
 		config := newConfig(configName, namespace)
 		cl := feedConfigMock(config)
 		secCl := feedSCCMock("privileged", t)
@@ -64,13 +65,13 @@ func TestConfigControllerReplaceImages(t *testing.T) {
 			deployment = "tekton-triggers-controller"
 			container  = "tekton_triggers_controller"
 			image      = "registry.redhat.io/osbs/controller:latest"
-			arg        = "el_image"
+			arg        = "_el_image"
 			argImage   = "registry.redhat.io/osbs/eventlistenersink:latest"
 		)
 
 		// GIVEN
-		os.Setenv("IMAGE_TRIGGERS_"+strings.ToUpper(container), image)
-		os.Setenv("IMAGE_TRIGGERS_ARG_"+strings.ToUpper(arg), argImage)
+		os.Setenv(trnsfm.TriggersImagePrefix+strings.ToUpper(container), image)
+		os.Setenv(trnsfm.TriggersImagePrefix+trnsfm.ArgPrefix+strings.ToUpper(arg), argImage)
 		config := newConfig(configName, namespace)
 		cl := feedConfigMock(config)
 		addons, err := mfFor("addons", cl)

--- a/pkg/utils/transform/transform.go
+++ b/pkg/utils/transform/transform.go
@@ -22,8 +22,12 @@ const (
 )
 
 const (
-	ARG_PREFIX   = "arg"
-	PARAM_PREFIX = "param"
+	PipelinesImagePrefix = "IMAGE_PIPELINES_"
+	TriggersImagePrefix  = "IMAGE_TRIGGERS_"
+	AddonsImagePrefix    = "IMAGE_ADDONS_"
+
+	ArgPrefix   = "arg_"
+	ParamPrefix = "param_"
 )
 
 // InjectDefaultSA adds default service account into config-defaults configMap
@@ -157,14 +161,14 @@ func replaceContainerImages(containers []corev1.Container, images map[string]str
 func replaceContainersArgsImage(container *corev1.Container, images map[string]string) {
 	for a, arg := range container.Args {
 		if argVal, hasArg := splitsByEqual(arg); hasArg {
-			argument := formKey(ARG_PREFIX, argVal[0])
+			argument := formKey(ArgPrefix, argVal[0])
 			if url, exist := images[argument]; exist {
 				container.Args[a] = argVal[0] + "=" + url
 			}
 			continue
 		}
 
-		argument := formKey(ARG_PREFIX, arg)
+		argument := formKey(ArgPrefix, arg)
 		if url, exist := images[argument]; exist {
 			container.Args[a+1] = url
 		}
@@ -175,7 +179,7 @@ func replaceContainersArgsImage(container *corev1.Container, images map[string]s
 func formKey(prefix, arg string) string {
 	argument := strings.ToLower(arg)
 	if prefix != "" {
-		argument = prefix + "_" + argument
+		argument = prefix + argument
 	}
 	return strings.ReplaceAll(argument, "-", "_")
 }
@@ -252,7 +256,7 @@ func replaceParamsImage(params []interface{}, override map[string]string) {
 			continue
 		}
 
-		name = formKey(PARAM_PREFIX, name)
+		name = formKey(ParamPrefix, name)
 		image, found := override[name]
 		if !found || image == "" {
 			transformLog.Info("Image not found", "step", name, "action", "skip")

--- a/pkg/utils/transform/transform_test.go
+++ b/pkg/utils/transform/transform_test.go
@@ -155,7 +155,7 @@ func TestReplaceImages(t *testing.T) {
 	})
 
 	t.Run("of_containers_args_by_space", func(t *testing.T) {
-		arg := ARG_PREFIX + "__bash_image"
+		arg := ArgPrefix + "__bash_image"
 		image := "foo.bar/image/bash"
 		images := map[string]string{
 			arg: image,
@@ -172,7 +172,7 @@ func TestReplaceImages(t *testing.T) {
 	})
 
 	t.Run("of_container_args_has_equal", func(t *testing.T) {
-		arg := ARG_PREFIX + "__nop"
+		arg := ArgPrefix + "__nop"
 		image := "foo.bar/image/nop"
 		images := map[string]string{
 			arg: image,
@@ -206,7 +206,7 @@ func TestReplaceImages(t *testing.T) {
 	})
 
 	t.Run("of_task_addons_param_image", func(t *testing.T) {
-		paramName := PARAM_PREFIX + "_builder_image"
+		paramName := ParamPrefix + "builder_image"
 		image := "foo.bar/image/buildah"
 		images := map[string]string{
 			paramName: image,


### PR DESCRIPTION
This patch changes the pipeline image prefix env var from
IMAGE_PIPELINE to IMAGE_PIPELINES.

Extract the string into constants under transform package