### PR TITLE
Use Tag based url to fetch pipeline payload

### DIFF
--- a/openshift/release/fetch-pipeline.sh
+++ b/openshift/release/fetch-pipeline.sh
@@ -10,7 +10,7 @@
 # modify this in future if a workflow based on latest version and recent (shifted) versions is needed
 MAX_SHIFT=1
 NIGHTLY_RELEASE="https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-next/openshift/release/tektoncd-pipeline-nightly.yaml"
-STABLE_RELEASE_URL='https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-${version}/openshift/release/tektoncd-pipeline-${version}.yaml'
+STABLE_RELEASE_URL='https://raw.githubusercontent.com/openshift/tektoncd-pipeline/${version}/openshift/release/tektoncd-pipeline-${version}.yaml'
 PAYLOAD_PIPELINE_VERSION="release-next"
 
 function get_version {


### PR DESCRIPTION
This will change the url to tag based from
branch based to fetch the pipeline release
yaml as the branch name and tag name can
be different like in case of beta release
we have branch name as v0.11.x and
tags as v0.11.0-rc2 and v0.11.0

Signed-off-by: Nikhil Thomas <nikthoma@redhat.com>