### PR TITLE
Fix pipeline template failure due to in-progress deployment

### DIFF
--- a/deploy/resources/v0.11.0-rc2/addons/pipelines/buildah/buildah-build-deploy.yaml
+++ b/deploy/resources/v0.11.0-rc2/addons/pipelines/buildah/buildah-build-deploy.yaml
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["rollout", "latest", "$(params.APP_NAME)"]
+          value: ["rollout", "status", "dc/$(params.APP_NAME)"]

--- a/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-go/s2i-go-build-deploy.yaml
+++ b/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-go/s2i-go-build-deploy.yaml
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["rollout", "latest", "$(params.APP_NAME)"]
+          value: ["rollout", "status", "dc/$(params.APP_NAME)"]

--- a/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml
+++ b/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-java-11/s2i-java-11-build-deploy.yaml
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["rollout", "latest", "$(params.APP_NAME)"]
+          value: ["rollout", "status", "dc/$(params.APP_NAME)"]

--- a/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-nodejs/s2i-nodejs-build-deploy.yaml
+++ b/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-nodejs/s2i-nodejs-build-deploy.yaml
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["rollout", "latest", "$(params.APP_NAME)"]
+          value: ["rollout", "status", "dc/$(params.APP_NAME)"]

--- a/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-perl/s2i-perl-build-deploy.yaml
+++ b/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-perl/s2i-perl-build-deploy.yaml
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["rollout", "latest", "$(params.APP_NAME)"]
+          value: ["rollout", "status", "dc/$(params.APP_NAME)"]

--- a/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-php/s2i-php-build-deploy.yaml
+++ b/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-php/s2i-php-build-deploy.yaml
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["rollout", "latest", "$(params.APP_NAME)"]
+          value: ["rollout", "status", "dc/$(params.APP_NAME)"]

--- a/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-python/s2i-python-build-deploy.yaml
+++ b/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-python/s2i-python-build-deploy.yaml
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["rollout", "latest", "$(params.APP_NAME)"]
+          value: ["rollout", "status", "dc/$(params.APP_NAME)"]

--- a/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-ruby/s2i-ruby-build-deploy.yaml
+++ b/deploy/resources/v0.11.0-rc2/addons/pipelines/s2i-ruby/s2i-ruby-build-deploy.yaml
@@ -42,4 +42,4 @@ spec:
         - build
       params:
         - name: ARGS
-          value: ["rollout", "latest", "$(params.APP_NAME)"]
+          value: ["rollout", "status", "dc/$(params.APP_NAME)"]


### PR DESCRIPTION
Fix as part of jira [SRVKP-637](https://issues.redhat.com/browse/SRVKP-637)

**Issue Description:**

When adding a pipeline on "Import from Git" flow, the pipeline run fails with the following error:

```
--> Creating resources ...
--> Failed
    error: deploymentconfigs.apps.openshift.io "simple-go-app" already exists
```
Because **DeploymentConfig(DC)** automatically start a new deployment when a new image is build due to the triggers that are set on them. This causes the deployment in pipeline to fail since a deployment is already in progress.

