### PR TITLE
Fix amending SCC privileged that blocks cluster upgrade

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -123,6 +123,7 @@ rules:
   verbs:
   - get
   - update
+  - create
   - use
 - apiGroups:
   - operator.tekton.dev

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -34,6 +34,8 @@ const (
 	ProviderTypeRedHat    = "redhat"
 	ProviderTypeCertified = "certified"
 
+	OperatorPrivilegedSCC = "privileged-openshift-pipelines"
+
 	uuidPath = "deploy/uuid"
 )
 


### PR DESCRIPTION

    Previously, operator used to append `tekton-pipeline-controller` SA to
    the SCC `privileged` which prevented openshift cluster upgrade[doc].
    From the [doc]:

    > Do not modify the default SCCs. Customizing the default SCCs can
    > lead to  issues when OpenShift Container Platform is upgraded.
    > Instead, create new SCCs.

    The solution is to create a new SCC like privileged which this patch implements.

    [doc]: https://docs.openshift.com/container-platform/4.3/authentication/managing-security-context-constraints.html

    Signed-off-by: Sunil Thaha <sthaha@redhat.com>