### PR TITLE
Update pipeline templates to use v1beta1 api version

### DIFF
--- a/deploy/resources/v0.11.1/addons/clustertasks/buildah/buildah-task.yaml
+++ b/deploy/resources/v0.11.1/addons/clustertasks/buildah/buildah-task.yaml
@@ -10,8 +10,6 @@ metadata:
   name: buildah
 spec:
   params:
-  - name: IMAGE
-    description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
     default: quay.io/buildah/stable:v1.11.0
@@ -27,14 +25,19 @@ spec:
   - name: FORMAT
     description: The format of the built container, oci or docker
     default: "oci"
-  workspaces:
-  - name: source
+  resources:
+    inputs:
+      - name: source
+        type: git
+    outputs:
+      - name: image
+        type: image
 
   steps:
   - name: build
     image: $(params.BUILDER_IMAGE)
-    workingDir: $(workspaces.source.path)
-    command: ['buildah', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(params.IMAGE)', '$(params.CONTEXT)']
+    workingDir: /workspace/source
+    command: ['buildah', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(resources.outputs.image.url)', '$(params.CONTEXT)']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
@@ -43,8 +46,8 @@ spec:
 
   - name: push
     image: $(params.BUILDER_IMAGE)
-    workingDir: $(workspaces.source.path)
-    command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+    workingDir: /workspace/source
+    command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers

--- a/deploy/resources/v0.11.1/addons/clustertasks/buildah/buildah-v0-11-1-task.yaml
+++ b/deploy/resources/v0.11.1/addons/clustertasks/buildah/buildah-v0-11-1-task.yaml
@@ -10,8 +10,6 @@ metadata:
   name: buildah-v0-11-1
 spec:
   params:
-  - name: IMAGE
-    description: Reference of the image buildah will produce.
   - name: BUILDER_IMAGE
     description: The location of the buildah builder image.
     default: quay.io/buildah/stable:v1.11.0
@@ -27,14 +25,19 @@ spec:
   - name: FORMAT
     description: The format of the built container, oci or docker
     default: "oci"
-  workspaces:
-  - name: source
+  resources:
+    inputs:
+      - name: source
+        type: git
+    outputs:
+      - name: image
+        type: image
 
   steps:
   - name: build
     image: $(params.BUILDER_IMAGE)
-    workingDir: $(workspaces.source.path)
-    command: ['buildah', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(params.IMAGE)', '$(params.CONTEXT)']
+    workingDir: /workspace/source
+    command: ['buildah', 'bud', '--format=$(params.FORMAT)', '--tls-verify=$(params.TLSVERIFY)', '--layers', '-f', '$(params.DOCKERFILE)', '-t', '$(resources.outputs.image.url)', '$(params.CONTEXT)']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers
@@ -43,8 +46,8 @@ spec:
 
   - name: push
     image: $(params.BUILDER_IMAGE)
-    workingDir: $(workspaces.source.path)
-    command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(params.IMAGE)', 'docker://$(params.IMAGE)']
+    workingDir: /workspace/source
+    command: ['buildah', 'push', '--tls-verify=$(params.TLSVERIFY)', '$(resources.outputs.image.url)', 'docker://$(resources.outputs.image.url)']
     volumeMounts:
     - name: varlibcontainers
       mountPath: /var/lib/containers

--- a/deploy/resources/v0.11.1/addons/clustertasks/s2i/s2i-task.yaml
+++ b/deploy/resources/v0.11.1/addons/clustertasks/s2i/s2i-task.yaml
@@ -21,11 +21,12 @@ spec:
     description: Log level when running the S2I binary
     default: '0'
   resources:
+    inputs:
+      - name: source
+        type: git
     outputs:
-    - name: image
-      type: image
-  workspaces:
-  - name: source
+      - name: image
+        type: image
   steps:
   - name: generate
     command:
@@ -40,7 +41,7 @@ spec:
     volumeMounts:
     - mountPath: /gen-source
       name: gen-source
-    workingDir: $(workspaces.source.path)
+    workingDir: /workspace/source
   - name: build
     command:
     - buildah

--- a/deploy/resources/v0.11.1/addons/clustertasks/s2i/s2i-v0-11-1-task.yaml
+++ b/deploy/resources/v0.11.1/addons/clustertasks/s2i/s2i-v0-11-1-task.yaml
@@ -21,11 +21,12 @@ spec:
     description: Log level when running the S2I binary
     default: '0'
   resources:
+    inputs:
+      - name: source
+        type: git
     outputs:
-    - name: image
-      type: image
-  workspaces:
-  - name: source
+      - name: image
+        type: image
   steps:
   - name: generate
     command:
@@ -40,7 +41,7 @@ spec:
     volumeMounts:
     - mountPath: /gen-source
       name: gen-source
-    workingDir: $(workspaces.source.path)
+    workingDir: /workspace/source
   - name: build
     command:
     - buildah

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment-config/buildah/buildah-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment-config/buildah/buildah-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: buildah

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-go/s2i-go-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-go/s2i-go-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-go

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-java-11/s2i-java-11-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-java-11/s2i-java-11-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-java-11

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-nodejs/s2i-nodejs-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-nodejs/s2i-nodejs-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-nodejs

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-perl/s2i-perl-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-perl/s2i-perl-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-perl

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-php/s2i-php-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-php/s2i-php-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-php

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-python/s2i-python-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-python/s2i-python-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-python-3

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-ruby/s2i-ruby-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment-config/s2i-ruby/s2i-ruby-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-ruby

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment/buildah/buildah-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment/buildah/buildah-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: buildah-deployment

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-go/s2i-go-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-go/s2i-go-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-go-deployment

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-java-11/s2i-java-11-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-java-11/s2i-java-11-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-java-11-deployment

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-nodejs/s2i-nodejs-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-nodejs/s2i-nodejs-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-nodejs-deployment

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-perl/s2i-perl-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-perl/s2i-perl-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-perl-deployment

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-php/s2i-php-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-php/s2i-php-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-php-deployment

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-python/s2i-python-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-python/s2i-python-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-python-3-deployment

--- a/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-ruby/s2i-ruby-build-deploy.yaml
+++ b/deploy/resources/v0.11.1/addons/pipelines/deployment/s2i-ruby/s2i-ruby-build-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1alpha1
+apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
   name: s2i-ruby-deployment

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -146,12 +146,6 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - triggers.tekton.dev
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
   - console.openshift.io
   resources:
   - consoleyamlsamples

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -146,6 +146,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - triggers.tekton.dev
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
   - console.openshift.io
   resources:
   - consoleyamlsamples


### PR DESCRIPTION
JIRA: [SRVKP-672](https://issues.redhat.com/browse/SRVKP-672)

**Note:**
Updated 2 cluster tasks `buildah`, `s2i` manually because upstream [catalog](https://github.com/tektoncd/catalog) have changes related to workspace but for TP release we are not going with workspace changes so modified cluster task to have apiVersion **v1beta1**  without the **workspace** changes
