### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ It allows overriding `ClusterTask` addons steps images.
 It allows overriding `ClusterTask` addons params images. the `_PARAM_` will replace the
 value of `Task.Spec.Param`.
 
-`Note: IF IMAGE NAME, IMAGE ARGUMENT, STEP NAME AND PARAMATER NAME HAS "-" IN IT, THEN PLEASE SUBSTITUTE IT BY "_"`
+`Note: IF IMAGE NAME, IMAGE ARGUMENT, STEP NAME AND PARAMETER NAME HAS "-" IN IT, THEN PLEASE SUBSTITUTE IT BY "_"`
 
 `Note: BE CAUTIOUS WHILE SUBSTITUTING THE IMAGES. FOR INSTANCE, IF DEPLOYMENT HAS MORE THAN ONE CONTAINER AND 
 CONTAINER HAS SAME NAME AS DEFINED IN THE OVERRIDE IMAGE CONFIGURATION, THEN THIS COULD RESULT IN UNWATED IMAGE SUBSTITUTATION` 
@@ -247,7 +247,7 @@ cd $GOPATH/src/github.com/operator-framework/operator-lifecycle-manager
 
 This section explains how to test changes to the operator by executing the entire end-to-end workflow of edit, test, build, package, etc... 
 
-It asssumes you have already followed install [minikube](#install-minikube) and [OLM](#install-olm).
+It assumes you have already followed install [minikube](#install-minikube) and [OLM](#install-olm).
 
 #### Generate new image, CSV
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -13,7 +13,7 @@
     * To make an official release use **QUAY_NAMESPACE=openshift-pipeline**
     * For local development/testing use **QUAY_NAMESPACE=\<your quay username\>**
     
-    * whereever **MY_QUAY_NAMESPACE** is specified (in OLM testing) always use **MY_QUAY_NAMESPACE=\<your quay username\>** 
+    * wherever **MY_QUAY_NAMESPACE** is specified (in OLM testing) always use **MY_QUAY_NAMESPACE=\<your quay username\>** 
 
 ## Branching
 

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -22,7 +22,7 @@ lint-yaml: ./vendor ${YAML_FILES}
 .PHONY: lint-go-code
 ## Checks the code with golangci-lint
 lint-go-code: ./vendor $(GOLANGCI_LINT_BIN)
-	# This is required for OpenShift CI enviroment
+	# This is required for OpenShift CI environment
 	# Ref: https://github.com/openshift/release/pull/3438#issuecomment-482053250
 	$(Q)XDG_CACHE_HOME=$(shell pwd)/out/cache \
 	GOCACHE=$(shell pwd)/out/gocache \

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -633,7 +633,7 @@ func createCR(c client.Client) error {
 
 	err := c.Create(context.TODO(), cr)
 	if errors.IsAlreadyExists(err) {
-		log.Info("skipped creation", "reason", "resoure already exists")
+		log.Info("skipped creation", "reason", "resource already exists")
 		return nil
 	}
 

--- a/pkg/utils/transform/transform.go
+++ b/pkg/utils/transform/transform.go
@@ -116,7 +116,7 @@ func InjectLabel(key, value string, overwritePolicy OverwritePolicy, kinds ...st
 		labels[key] = value
 		err = unstructured.SetNestedStringMap(u.Object, labels, "metadata", "labels")
 		if err != nil {
-			return fmt.Errorf("error updating labes for %s:%s, %s", kind, u.GetName(), err)
+			return fmt.Errorf("error updating labels for %s:%s, %s", kind, u.GetName(), err)
 		}
 		return nil
 	}

--- a/pkg/utils/transform/transform.go
+++ b/pkg/utils/transform/transform.go
@@ -92,7 +92,7 @@ func ReplaceKind(fromKind, toKind string) mf.Transformer {
 }
 
 //InjectLabel adds label key:value to a resource
-// overwritePolicy (Retain/Overwrite) decides whehther to overwite an already existing label
+// overwritePolicy (Retain/Overwrite) decides whehther to overwrite an already existing label
 // []kinds specify the Kinds on which the label should be applied
 // if len(kinds) = 0, label will be apllied to all/any resources irrespective of its Kind
 func InjectLabel(key, value string, overwritePolicy OverwritePolicy, kinds ...string) mf.Transformer {
@@ -116,7 +116,7 @@ func InjectLabel(key, value string, overwritePolicy OverwritePolicy, kinds ...st
 		labels[key] = value
 		err = unstructured.SetNestedStringMap(u.Object, labels, "metadata", "labels")
 		if err != nil {
-			return fmt.Errorf("error updateing labes for %s:%s, %s", kind, u.GetName(), err)
+			return fmt.Errorf("error updating labes for %s:%s, %s", kind, u.GetName(), err)
 		}
 		return nil
 	}


### PR DESCRIPTION
Hello,

This PR will fix : 

- 2 typos in `README.md`
- 1 typo in `docs/release.md`
- 1 typo in `make/lint.mk`
- 1 typo in `pkg/controller/config/config_controller.go`
- 2 typos in `pkg/utils/transform/transform.go`



Cheers! :robot: