### PR TITLE
Update e2e test target

### DIFF
--- a/make/lint.mk
+++ b/make/lint.mk
@@ -29,12 +29,7 @@ lint-go-code: ./vendor $(GOLANGCI_LINT_BIN)
 	./out/golangci-lint ${V_FLAG} run --deadline=30m
 
 $(GOLANGCI_LINT_BIN):
-	$(Q) GO111MODULE=on \
-		GOBIN=$(shell pwd)/out \
-		go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
-
-	# re-enable this when the fix for the issue is released
-	#$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.16.0
+	$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.25.1
 
 .PHONY: courier
 ## Validate manifests using operator-courier

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -29,8 +29,6 @@ lint-go-code: ./vendor $(GOLANGCI_LINT_BIN)
 	./out/golangci-lint ${V_FLAG} run --deadline=30m
 
 $(GOLANGCI_LINT_BIN):
-	# HACK: fix golang-ci giving errors with utf8
-	# see: https://github.com/golangci/golangci-lint/issues/658
 	$(Q) GO111MODULE=on \
 		GOBIN=$(shell pwd)/out \
 		go get -u github.com/golangci/golangci-lint/cmd/golangci-lint

--- a/make/test.mk
+++ b/make/test.mk
@@ -46,12 +46,7 @@ get-operator-version:
 ## Runs the e2e tests locally
 test-e2e: e2e-setup
 	$(info Running E2E test: $@)
-	$(Q) rm -rf vendor/
-	$(Q)operator-sdk test local ./test/e2e \
-		--image ${IMAGE_FORMAT}tektoncd-pipeline-operator \
-		--namespace $(TEST_NAMESPACE) \
-		--go-test-flags "-v -timeout=15m" \
-	 	--debug
+	./test/e2e-tests.sh $(TEST_NAMESPACE)
 
 .PHONY: e2e-setup
 e2e-setup: get-test-namespace

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+TEST_NAMESPACE=$1
+
+if [ -z $TEST_NAMESPACE ]; then
+  echo TEST_NAMESPACE is not set
+  exit 1
+fi
+
+operator-sdk test local ./test/e2e \
+  --image ${IMAGE_FORMAT//\$\{component\}/tektoncd-pipeline-operator} \
+	--namespace ${TEST_NAMESPACE} \
+	--go-test-flags "-v -timeout=15m" \
+	--debug


### PR DESCRIPTION
Refactor lint make target

Remove hack as the root issue is fixed in golangci-lint

Update golangci-lint to v1.25.1

Add e2e-tests.sh script to improve handling of new ci IMAGE_FORMAT variable substitution.