### PR TITLE
Update non redhat resources to use image value from env

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,6 +24,8 @@ spec:
         env:
         - name: WATCH_NAMESPACE
           value: ""
+        - name: IMAGE_ADDONS_PARAM_KN_IMAGE
+          value: registry.redhat.io/openshift-serverless-1/client-kn-rhel8
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -326,10 +326,12 @@ func (r *ReconcileConfig) applyCommunityResources(req reconcile.Request, cfg *op
 	log := requestLogger(req, "apply-non-redhat-resources")
 
 	//add TaskProviderType label to ClusterTasks (community, redhat, certified)
+	addonImages := transform.ToLowerCaseKeys(imagesFromEnv(transform.AddonsImagePrefix))
 	addnTfrms := []mf.Transformer{
 		// replace kind: Task, with kind: ClusterTask
 		transform.ReplaceKind("Task", "ClusterTask"),
 		transform.InjectLabel(flag.LabelProviderType, flag.ProviderTypeCommunity, transform.Overwrite),
+		transform.TaskImages(addonImages),
 	}
 	if err := transformManifest(cfg, &r.community, addnTfrms...); err != nil {
 		log.Error(err, "failed to apply manifest transformations on pipeline-addons")

--- a/scripts/update-tasks.sh
+++ b/scripts/update-tasks.sh
@@ -34,7 +34,7 @@ USAGE:
     $SCRIPT_NAME CATALOG_VERSION DEST_DIR VERSION
 
 Example:
-  $SCRIPT_NAME release-v0.7 deploy/resources/v0.7.0 0.7.0
+  $SCRIPT_NAME release-v0.7 deploy/resources/v0.7.0 v0.7.0
 EOF
   exit 1
 }


### PR DESCRIPTION
JIRA : [SRVKP-697](https://issues.redhat.com/browse/SRVKP-697)

**Changes:**
[Kn](https://github.com/openshift/tektoncd-pipeline-operator/blob/master/pkg/flag/flag.go#L57) has been installed as part of [applyCommunityResources](https://github.com/openshift/tektoncd-pipeline-operator/blob/master/pkg/controller/config/config_controller.go#L357)
Added logic to update the params image

**Test:**
set
```
export IMAGE_ADDONS_PARAM_KN_IMAGE=registry.redhat.io/openshift-serverless-1/client-kn-rhel8
```
and run 
```
operator-sdk up local --namespace=""
```
to verify the `kn` task updated with the provided image

To make sure the updated image works fine test with `kn` **[TaskRun](https://github.com/openshift/tektoncd-catalog/tree/release-v0.11/kn)**