### PR TITLE
Fix lint CI

### DIFF
--- a/make/lint.mk
+++ b/make/lint.mk
@@ -33,7 +33,7 @@ $(GOLANGCI_LINT_BIN):
 	# see: https://github.com/golangci/golangci-lint/issues/658
 	$(Q) GO111MODULE=on \
 		GOBIN=$(shell pwd)/out \
-		go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+		go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.24.0
 
 	# re-enable this when the fix for the issue is released
 	#$(Q)curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ./out v1.16.0


### PR DESCRIPTION
This will fix the lint CI failing as some issue
in installing latest golangci-lint

Now it will install the last stable release
I have followed https://github.com/golangci/golangci-lint/issues/1087
to fix this