### PR TITLE
fix crashloopbackoff of tekton-pipelines-webhook

### DIFF
--- a/deploy/resources/devel/pipelines/00-release.yaml
+++ b/deploy/resources/devel/pipelines/00-release.yaml
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -33,6 +34,7 @@ metadata:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -63,23 +65,34 @@ spec:
       max: 65535
 
 ---
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: tekton-pipelines-admin
+  name: tekton-pipelines-controller-cluster-access
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "namespaces", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims", "limitranges"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["apps"]
-    resources: ["deployments/finalizers"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
-  - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+    # Namespace access is required because the controller timeout handling logic
+    # iterates over all namespaces and times out any PipelineRuns that have expired.
+    # Pod access is required because the taskrun controller wants to be updated when
+    # a Pod underlying a TaskRun changes state.
+    resources: ["namespaces", "pods"]
+    verbs: ["list", "watch"]
+    # Controller needs cluster access to all of the CRDs that it is responsible for
+    # managing.
   - apiGroups: ["tekton.dev"]
     resources: ["tasks", "clustertasks", "taskruns", "pipelines", "pipelineruns", "pipelineresources", "conditions"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
@@ -93,6 +106,116 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["tekton-pipelines"]
     verbs: ["use"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  # This is the access that the controller needs on a per-namespace basis.
+  name: tekton-pipelines-controller-tenant-access
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "secrets", "events", "serviceaccounts", "configmaps", "persistentvolumeclaims", "limitranges"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+    # Unclear if this access is actually required.  Simply a hold-over from the previous
+    # incarnation of the controller's ClusterRole.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/finalizers"]
+    verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-webhook-cluster-access
+rules:
+  # The webhook needs to be able to list and update customresourcedefinitions,
+  # mainly to update the webhook certificates.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
+    verbs: ["get", "list", "update", "patch", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    # The webhook performs a reconciliation on these two resources and continuously
+    # updates configuration.
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    # knative starts informers on these things, which is why we need get, list and watch.
+    verbs: ["list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    # This mutating webhook is responsible for applying defaults to tekton objects
+    # as they are received.
+    resourceNames: ["webhook.pipeline.tekton.dev"]
+    # When there are changes to the configs or secrets, knative updates the mutatingwebhook config
+    # with the updated certificates or the refreshed set of rules.
+    verbs: ["get", "update"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    # validation.webhook.pipeline.tekton.dev performs schema validation when you, for example, create TaskRuns.
+    # config.webhook.pipeline.tekton.dev validates the logging configuration against knative's logging structure
+    resourceNames: ["validation.webhook.pipeline.tekton.dev", "config.webhook.pipeline.tekton.dev"]
+    # When there are changes to the configs or secrets, knative updates the validatingwebhook config
+    # with the updated certificates or the refreshed set of rules.
+    verbs: ["get", "update"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    resourceNames: ["tekton-pipelines"]
+    verbs: ["use"]
+
+---
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["list", "watch"]
+  # The controller needs access to these configmaps for logging information and runtime configuration.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+    resourceNames: ["config-logging", "config-observability", "config-artifact-bucket", "config-artifact-pvc", "feature-flags", "config-leader-election"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["list", "watch"]
+  # The webhook needs access to these configmaps for logging information.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+    resourceNames: ["config-logging", "config-observability"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list", "watch"]
+  # The webhook daemon makes a reconciliation loop on webhook-certs. Whenever
+  # the secret changes it updates the webhook configurations with the certificates
+  # stored in the secret.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "update"]
+    resourceNames: ["webhook-certs"]
 
 ---
 # Copyright 2019 The Tekton Authors
@@ -113,6 +236,12 @@ kind: ServiceAccount
 metadata:
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
 
 ---
 # Copyright 2019 The Tekton Authors
@@ -128,17 +257,91 @@ metadata:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: tekton-pipelines-controller-admin
+  name: tekton-pipelines-controller-cluster-access
 subjects:
   - kind: ServiceAccount
     name: tekton-pipelines-controller
     namespace: tekton-pipelines
 roleRef:
   kind: ClusterRole
-  name: tekton-pipelines-admin
+  name: tekton-pipelines-controller-cluster-access
+  apiGroup: rbac.authorization.k8s.io
+---
+# If this ClusterRoleBinding is replaced with a RoleBinding
+# then the ClusterRole would be namespaced. The access described by
+# the tekton-pipelines-controller-tenant-access ClusterRole would
+# be scoped to individual tenant namespaces.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-controller-tenant-access
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-controller
+    namespace: tekton-pipelines
+roleRef:
+  kind: ClusterRole
+  name: tekton-pipelines-controller-tenant-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-webhook-cluster-access
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-webhook
+    namespace: tekton-pipelines
+roleRef:
+  kind: ClusterRole
+  name: tekton-pipelines-webhook-cluster-access
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Copyright 2020 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-controller
+    namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: tekton-pipelines-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tekton-pipelines-webhook
+  namespace: tekton-pipelines
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-webhook
+    namespace: tekton-pipelines
+roleRef:
+  kind: Role
+  name: tekton-pipelines-webhook
   apiGroup: rbac.authorization.k8s.io
 
 ---
@@ -155,12 +358,28 @@ roleRef:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clustertasks.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   group: tekton.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      # One can use x-kubernetes-preserve-unknown-fields: true
+      # at the root of the schema (and inside any properties, additionalProperties)
+      # to get the traditional CRD behaviour that nothing is pruned, despite
+      # setting spec.preserveUnknownProperties: false.
+      #
+      # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+      # See issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true
@@ -179,7 +398,12 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines
 
 ---
 # Copyright 2019 The Tekton Authors
@@ -195,10 +419,14 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: conditions.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   group: tekton.dev
   names:
@@ -228,7 +456,7 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
----
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -265,12 +493,28 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pipelineruns.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   group: tekton.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      # One can use x-kubernetes-preserve-unknown-fields: true
+      # at the root of the schema (and inside any properties, additionalProperties)
+      # to get the traditional CRD behaviour that nothing is pruned, despite
+      # setting spec.preserveUnknownProperties: false.
+      #
+      # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+      # See issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true
@@ -305,7 +549,12 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines
 
 ---
 # Copyright 2019 The Tekton Authors
@@ -321,12 +570,28 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pipelines.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   group: tekton.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      # One can use x-kubernetes-preserve-unknown-fields: true
+      # at the root of the schema (and inside any properties, additionalProperties)
+      # to get the traditional CRD behaviour that nothing is pruned, despite
+      # setting spec.preserveUnknownProperties: false.
+      #
+      # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+      # See issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true
@@ -345,7 +610,12 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines
 
 ---
 # Copyright 2019 The Tekton Authors
@@ -361,10 +631,14 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: pipelineresources.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   group: tekton.dev
   names:
@@ -394,12 +668,28 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: taskruns.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   group: tekton.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      # One can use x-kubernetes-preserve-unknown-fields: true
+      # at the root of the schema (and inside any properties, additionalProperties)
+      # to get the traditional CRD behaviour that nothing is pruned, despite
+      # setting spec.preserveUnknownProperties: false.
+      #
+      # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+      # See issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true
@@ -434,7 +724,12 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines
 
 ---
 # Copyright 2019 The Tekton Authors
@@ -450,12 +745,28 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: tasks.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   group: tekton.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      # One can use x-kubernetes-preserve-unknown-fields: true
+      # at the root of the schema (and inside any properties, additionalProperties)
+      # to get the traditional CRD behaviour that nothing is pruned, despite
+      # setting spec.preserveUnknownProperties: false.
+      #
+      # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+      # See issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
   versions:
   - name: v1alpha1
     served: true
@@ -474,7 +785,12 @@ spec:
   # starts to increment
   subresources:
     status: {}
-  version: v1alpha1
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines
 
 ---
 # Copyright 2020 The Tekton Authors
@@ -497,30 +813,16 @@ metadata:
   name: webhook-certs
   namespace: tekton-pipelines
   labels:
-    pipeline.tekton.dev/release: v0.11.3
+    pipeline.tekton.dev/release: v0.12.1
 # The data is populated at install time.
 
 ---
-# Copyright 2020 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.pipeline.tekton.dev
   labels:
-    pipeline.tekton.dev/release: v0.11.3
+    pipeline.tekton.dev/release: v0.12.1
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -531,27 +833,14 @@ webhooks:
   failurePolicy: Fail
   sideEffects: None
   name: validation.webhook.pipeline.tekton.dev
----
-# Copyright 2020 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
+---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.pipeline.tekton.dev
   labels:
-    pipeline.tekton.dev/release: v0.11.3
+    pipeline.tekton.dev/release: v0.12.1
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -562,27 +851,14 @@ webhooks:
   failurePolicy: Fail
   sideEffects: None
   name: webhook.pipeline.tekton.dev
----
-# Copyright 2020 The Tekton Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
+---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.pipeline.tekton.dev
   labels:
-    pipeline.tekton.dev/release: v0.11.3
+    pipeline.tekton.dev/release: v0.12.1
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -599,6 +875,20 @@ webhooks:
       operator: Exists
 
 ---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -627,6 +917,20 @@ rules:
   - watch
 
 ---
+# Copyright 2019 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -802,6 +1106,33 @@ data:
   disable-working-directory-overwrite: "false"
 
 ---
+# Copyright 2020 Tekton Authors LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election
+  namespace: tekton-pipelines
+data:
+  # An inactive but valid configuration follows; see example.
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+
+---
 # Copyright 2019 Tekton Authors LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -923,6 +1254,7 @@ data:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -931,8 +1263,8 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-pipelines
     app.kubernetes.io/component: controller
-    pipeline.tekton.dev/release: v0.11.3
-    version: v0.11.3
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   replicas: 1
   selector:
@@ -947,24 +1279,28 @@ spec:
         app.kubernetes.io/name: tekton-pipelines
         app.kubernetes.io/component: controller
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: v0.11.3
-        version: v0.11.3
+        pipeline.tekton.dev/release: v0.12.1
+        version: v0.12.1
     spec:
       serviceAccountName: tekton-pipelines-controller
       containers:
       - name: tekton-pipelines-controller
-        image: quay.io/openshift-pipeline/tektoncd-pipeline-controller:v0.11.3
+        image: quay.io/openshift-pipeline/tektoncd-pipeline-controller:v0.12.1
         args: [
-          "-kubeconfig-writer-image", "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v0.11.3",
-          "-creds-image", "quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:v0.11.3",
-          "-git-image", "quay.io/openshift-pipeline/tektoncd-pipeline-git-init:v0.11.3",
-          "-nop-image", "quay.io/openshift-pipeline/tektoncd-pipeline-nop:v0.11.3",
+          # These images are built on-demand by `ko resolve` and are replaced
+          # by image references by digest.
+          "-kubeconfig-writer-image", "quay.io/openshift-pipeline/tektoncd-pipeline-kubeconfigwriter:v0.12.1",
+          "-creds-image", "quay.io/openshift-pipeline/tektoncd-pipeline-creds-init:v0.12.1",
+          "-git-image", "quay.io/openshift-pipeline/tektoncd-pipeline-git-init:v0.12.1",
+          "-entrypoint-image", "quay.io/openshift-pipeline/tektoncd-pipeline-entrypoint:v0.12.1",
+          "-imagedigest-exporter-image", "quay.io/openshift-pipeline/tektoncd-pipeline-imagedigestexporter:v0.12.1",
+          "-pr-image", "quay.io/openshift-pipeline/tektoncd-pipeline-pullrequest-init:v0.12.1",
+          "-build-gcs-fetcher-image", "quay.io/openshift-pipeline/tektoncd-pipeline-gcs-fetcher:v0.12.1",
+
+          # These images are pulled from Dockerhub, by digest, as of April 15, 2020.
+          "-nop-image", "quay.io/openshift-pipeline/tektoncd-pipeline-nop:v0.12.1",
           "-shell-image", "registry.access.redhat.com/ubi8/ubi-minimal:latest",
-          "-gsutil-image", "google/cloud-sdk",
-          "-entrypoint-image", "quay.io/openshift-pipeline/tektoncd-pipeline-entrypoint:v0.11.3",
-          "-imagedigest-exporter-image", "quay.io/openshift-pipeline/tektoncd-pipeline-imagedigestexporter:v0.11.3",
-          "-pr-image", "quay.io/openshift-pipeline/tektoncd-pipeline-pullrequest-init:v0.11.3",
-          "-build-gcs-fetcher-image", "quay.io/openshift-pipeline/tektoncd-pipeline-gcs-fetcher:v0.11.3",
+          "-gsutil-image", "google/cloud-sdk@sha256:6e8676464c7581b2dc824956b112a61c95e4144642bec035e6db38e3384cae2e",
         ]
         volumeMounts:
         - name: config-logging
@@ -974,6 +1310,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # If you are changing these names, you will also need to update
+        # the controller's Role in 200-role.yaml to include the new
+        # values in the "configmaps" "get" rule.
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
@@ -982,6 +1321,10 @@ spec:
           value: config-artifact-bucket
         - name: CONFIG_ARTIFACT_PVC_NAME
           value: config-artifact-pvc
+        - name: CONFIG_FEATURE_FLAGS_NAME
+          value: feature-flags
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
       volumes:
@@ -994,8 +1337,8 @@ kind: Service
 metadata:
   labels:
     app: tekton-pipelines-controller
-    pipeline.tekton.dev/release: v0.11.3
-    version: v0.11.3
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
 spec:
@@ -1033,8 +1376,8 @@ metadata:
   labels:
     app.kubernetes.io/name: tekton-pipelines
     app.kubernetes.io/component: webhook-controller
-    pipeline.tekton.dev/release: v0.11.3
-    version: v0.11.3
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
 spec:
   replicas: 1
   selector:
@@ -1050,26 +1393,33 @@ spec:
         role: webhook
         app.kubernetes.io/name: tekton-pipelines
         app.kubernetes.io/component: webhook-controller
-        pipeline.tekton.dev/release: v0.11.3
-        version: v0.11.3
+        pipeline.tekton.dev/release: v0.12.1
+        version: v0.12.1
     spec:
-      serviceAccountName: tekton-pipelines-controller
+      serviceAccountName: tekton-pipelines-webhook
       containers:
       - name: webhook
         # This is the Go import path for the binary that is containerized
         # and substituted here.
-        image: quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.11.3
+        image: quay.io/openshift-pipeline/tektoncd-pipeline-webhook:v0.12.1
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # If you are changing these names, you will also need to update
+        # the webhook's Role in 200-role.yaml to include the new
+        # values in the "configmaps" "get" rule.
         - name: CONFIG_LOGGING_NAME
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election
         - name: WEBHOOK_SERVICE_NAME
           value: tekton-pipelines-webhook
+        - name: WEBHOOK_SECRET_NAME
+          value: webhook-certs
         - name: METRICS_DOMAIN
           value: tekton.dev/pipeline
         securityContext:
@@ -1089,8 +1439,8 @@ metadata:
   labels:
     app: tekton-pipelines-webhook
     role: webhook
-    pipeline.tekton.dev/release: v0.11.3
-    version: v0.11.3
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
 spec:

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -362,6 +362,8 @@ func transformManifest(cfg *op.Config, m *mf.Manifest, addnTfrms ...mf.Transform
 	tfs := []mf.Transformer{
 		mf.InjectOwner(cfg),
 		transform.InjectNamespaceConditional(flag.AnnotationPreserveNS, cfg.Spec.TargetNamespace),
+		transform.InjectNamespaceRoleBindingSubjects(cfg.Spec.TargetNamespace),
+		transform.InjectNamespaceCRDWebhookClientConfig(cfg.Spec.TargetNamespace),
 		transform.InjectDefaultSA(flag.DefaultSA),
 	}
 	tfs = append(tfs, addnTfrms...)

--- a/pkg/utils/transform/testdata/inject-ns-crd-webhookclientconf-no-ns.yaml
+++ b/pkg/utils/transform/testdata/inject-ns-crd-webhookclientconf-no-ns.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
+spec:
+  group: tekton.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: ClusterTask
+    plural: clustertasks
+    categories:
+    - tekton
+    - tekton-pipelines
+  scope: Cluster
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook

--- a/pkg/utils/transform/testdata/inject-ns-crd-webhookclientconf.yaml
+++ b/pkg/utils/transform/testdata/inject-ns-crd-webhookclientconf.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clustertasks.tekton.dev
+  labels:
+    pipeline.tekton.dev/release: v0.12.1
+    version: v0.12.1
+spec:
+  group: tekton.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false
+  names:
+    kind: ClusterTask
+    plural: clustertasks
+    categories:
+    - tekton
+    - tekton-pipelines
+  scope: Cluster
+  subresources:
+    status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: tekton-pipelines-webhook
+        namespace: tekton-pipelines

--- a/pkg/utils/transform/testdata/inject-ns-rolebinding-no-ns.yaml
+++ b/pkg/utils/transform/testdata/inject-ns-rolebinding-no-ns.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-pipelines-prometheus-k8s-read-binding
+  namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-pipelines-read
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s

--- a/pkg/utils/transform/testdata/inject-ns-rolebinding.yaml
+++ b/pkg/utils/transform/testdata/inject-ns-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-pipelines-prometheus-k8s-read-binding
+  namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-pipelines-read
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring

--- a/pkg/utils/transform/transform.go
+++ b/pkg/utils/transform/transform.go
@@ -65,8 +65,45 @@ func InjectNamespaceConditional(preserveNamespace, targetNamespace string) mf.Tr
 		if ok && val == "true" {
 			return nil
 		}
-
 		return tf(u)
+	}
+}
+
+func InjectNamespaceRoleBindingSubjects(targetNamespace string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		kind := strings.ToLower(u.GetKind())
+		if kind != "rolebinding" {
+			return nil
+		}
+		subjects, found, err := unstructured.NestedFieldNoCopy(u.Object, "subjects")
+		if !found || err != nil {
+			return err
+		}
+		for _, subject := range subjects.([]interface{}) {
+			m := subject.(map[string]interface{})
+			if _, ok := m["namespace"]; ok {
+				m["namespace"] = targetNamespace
+			}
+		}
+		return nil
+	}
+}
+
+func InjectNamespaceCRDWebhookClientConfig(targetNamespace string) mf.Transformer {
+	return func(u *unstructured.Unstructured) error {
+		kind := strings.ToLower(u.GetKind())
+		if kind != "customresourcedefinition" {
+			return nil
+		}
+		service, found, err := unstructured.NestedFieldNoCopy(u.Object, "spec", "conversion", "webhookClientConfig", "service")
+		if !found || err != nil {
+			return err
+		}
+		m := service.(map[string]interface{})
+		if _, ok := m["namespace"]; ok {
+			m["namespace"] = targetNamespace
+		}
+		return nil
 	}
 }
 


### PR DESCRIPTION
with pipeline 0.12.1 tekton-pipelines-webhook pod goes to
crashloopbackoff state as it tries to get pipelines webhook
service in different namespace

this adds transform function to put the correct namespace