### PR TITLE
Fixed ODC-4234

### DIFF
--- a/deploy/resources/devel/addons/02-clustertriggerbindings/github.yaml
+++ b/deploy/resources/devel/addons/02-clustertriggerbindings/github.yaml
@@ -44,7 +44,7 @@ spec:
   - name: content-type
     value: $(header.Content-Type)
   - name: pusher-name
-    value: $(body.name)
+    value: $(body.pusher.name)
 
 ---
 apiVersion: triggers.tekton.dev/v1alpha1


### PR DESCRIPTION
Fix for https://issues.redhat.com/browse/SRVKP-776 and https://issues.redhat.com/browse/ODC-4234

When creating a Trigger, the ClusterTriggerBinding template for a github push is looking for the value $(body.name) in the Github payload. The pusher name from Github is actually located at $(body.pusher.name) in the payload.

Changed the ClusterBindingTrigger yaml file to reflect this.