### PR TITLE
fetch-versions: Cleanups the testing logics and make it more robust

### DIFF
--- a/openshift/release/fetch-pipeline.sh
+++ b/openshift/release/fetch-pipeline.sh
@@ -8,38 +8,40 @@
 
 # set max shift to 0, so that when a version is explicitly specified that version is fetched
 # modify this in future if a workflow based on latest version and recent (shifted) versions is needed
-set -e
+set -eu
 
-set -x
-CURL_OPTIONS="-v" # -s for quiet, -v if you want debug
+CURL_OPTIONS="-s" # -s for quiet, -v if you want debug
 
 MAX_SHIFT=1
 NIGHTLY_RELEASE="https://raw.githubusercontent.com/openshift/tektoncd-pipeline/release-next/openshift/release/tektoncd-pipeline-nightly.yaml"
 STABLE_RELEASE_URL='https://raw.githubusercontent.com/openshift/tektoncd-pipeline/${version}/openshift/release/tektoncd-pipeline-${version}.yaml'
 PAYLOAD_PIPELINE_VERSION="release-next"
 
+TMPFILE=$(mktemp /tmp/.mm.XXXXXX)
+clean() { rm -f ${TMPFILE}; }
+trap clean EXIT
+
 function get_version {
     local shift=${1} # 0 is latest, increase is the version before etc...
-    tmpf=$(mktemp /tmp/.XXXXXX)
-    curl -f ${CURL_OPTIONS} -o ${tmpf} -v https://api.github.com/repos/tektoncd/pipeline/releases
-    local version=$(python -c "from pkg_resources import parse_version;import sys, json;jeez=json.load(open('${tmpf}'));print(sorted([x['tag_name'] for x in jeez], key=parse_version, reverse=True)[${shift}])")
+    curl -f ${CURL_OPTIONS} -o ${TMPFILE} https://api.github.com/repos/tektoncd/pipeline/releases
+    local version=$(python -c "from pkg_resources import parse_version;import json;jeez=json.load(open('${TMPFILE}'));print(sorted([x['tag_name'] for x in jeez], key=parse_version, reverse=True)[${shift}])")
     PAYLOAD_PIPELINE_VERSION=${version}
     echo $(eval echo ${STABLE_RELEASE_URL})
 }
 
 function tryurl {
-    curl -s -o /dev/null -f ${1} || return 1
+    curl --fail-early ${CURL_OPTIONS} -o /dev/null -f ${1} || return 1
 }
 
 function geturl() {
 
-    # for (( i = 0; i < 10; i++ )); do
-    #   if tryurl ${NIGHTLY_RELEASE};then
-    #       echo ${NIGHTLY_RELEASE}
-    #       return 0
-    #   fi
-    #   sleep 30s
-    # done
+    for (( i = 0; i < 10; i++ )); do
+      if tryurl ${NIGHTLY_RELEASE};then
+          echo ${NIGHTLY_RELEASE}
+          return 0
+      fi
+      sleep 30s
+    done
 
     for shifted in `seq 0 ${MAX_SHIFT}`;do
         versionyaml=$(get_version ${shifted})
@@ -55,5 +57,8 @@ function geturl() {
 URL=$(geturl)
 echo Pipeline Payload URL: ${URL}
 
-[[ -d ${1}/pipelines ]] || mkdir -p ${1}/pipelines
-curl -Ls ${URL} -o ${1}/pipelines/release.yaml
+# setting this a default so set -u is not failing
+arg=${1:-"/tmp"}
+
+[[ -d ${arg}/pipelines ]] || mkdir -p ${arg}/pipelines
+curl -Ls ${URL} -o ${arg}/pipelines/release.yaml


### PR DESCRIPTION
add CURL_OPTIONS so we can debug curl command if needed
set -e and set -u
read the github json from the temporary file...
make sure to --failearly with curl when trying url if needed


<img width="1386" alt="image" src="https://user-images.githubusercontent.com/98980/88162276-6f2dbc00-cc11-11ea-8854-39997e37e2be.png">

(second try with commented logic to get nightly so we try getting the releases)

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>