### PR TITLE
Fix crd for upgrade from old version

### DIFF
--- a/deploy/crds/operator_v1alpha1_config_crd.yaml
+++ b/deploy/crds/operator_v1alpha1_config_crd.yaml
@@ -53,8 +53,6 @@ spec:
                     type: string
                 required:
                 - code
-                - pipelineVersion
-                - triggersVersion
                 - version
                 type: object
               type: array

--- a/pkg/apis/operator/v1alpha1/config_types.go
+++ b/pkg/apis/operator/v1alpha1/config_types.go
@@ -40,10 +40,10 @@ type ConfigCondition struct {
 	Version string `json:"version"`
 
 	// The version of OpenShift pipelines
-	PipelineVersion string `json:"pipelineVersion"`
+	PipelineVersion string `json:"pipelineVersion,omitempty"`
 
 	// The version of OpenShift triggers
-	TriggersVersion string `json:"triggersVersion"`
+	TriggersVersion string `json:"triggersVersion,omitempty"`
 }
 
 // InstallStatus describes the state of installation of pipelines

--- a/pkg/apis/operator/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/operator/v1alpha1/zz_generated.openapi.go
@@ -105,7 +105,7 @@ func schema_pkg_apis_operator_v1alpha1_ConfigCondition(ref common.ReferenceCallb
 						},
 					},
 				},
-				Required: []string{"code", "version", "pipelineVersion", "triggersVersion"},
+				Required: []string{"code", "version"},
 			},
 		},
 	}


### PR DESCRIPTION
This will make the pipelineVersion and triggersVersion
field optional to have smooth upgrade from old version