### PR TITLE
Add functional to delete triggers

### DIFF
--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -719,6 +719,11 @@ func (r *ReconcileConfig) reconcileDeletion(req reconcile.Request, cfg *op.Confi
 		return reconcile.Result{}, err
 	}
 
+	if err := r.triggers.Delete(propPolicy); err != nil {
+		log.Error(err, "failed to delete triggers")
+		return reconcile.Result{}, err
+	}
+
 	if err := r.pipeline.Delete(propPolicy); err != nil {
 		log.Error(err, "failed to delete pipeline core")
 		return reconcile.Result{}, err


### PR DESCRIPTION
As we moved triggers into separate resource from addons
the deleteFunction missed for that change and
triggers are not getting deleted on uninstall