### PR TITLE
Refactor the update-to-head script

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -5,6 +5,7 @@
 
 set -e
 BRANCH_NAME=release-next
+VERSION=release-next
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 REPO_NAME=`basename ${PROJECT_ROOT}`
@@ -17,20 +18,27 @@ PAYLOAD_ROOT=${PROJECT_ROOT}/deploy/resources
 git fetch openshift master
 git checkout openshift/master -B ${BRANCH_NAME}
 
-#get pipeline manifest
+# get pipeline manifest
 ${PROJECT_ROOT}/openshift/release/fetch-pipeline.sh ${PAYLOAD_ROOT}
 
+# update flag value to release-next
+sed -i 's/^[[:space:]]*TektonVersion.*/TektonVersion = "'${VERSION}'"/' ${PROJECT_ROOT}/pkg/flag/flag.go
+go fmt ${PROJECT_ROOT}/pkg/flag/flag.go
+
+# commit changes to release-next
 git add deploy/resources
+git add pkg/flag/flag.go
 git commit -m ":Add nightly or last release pipeline manifest"
 git push -f openshift release-next
 
-# Trigger CI
+# commit changes to release-next-ci
 git checkout release-next -B release-next-ci
 date > ci
 git add ci
 git commit -m ":robot: Triggering CI on branch 'release-next' after synching to openshift/master"
 git push -f openshift release-next-ci
 
+# Trigger CI by raising a PR
 if hash hub 2>/dev/null; then
    hub pull-request --no-edit -l "kind/sync-fork-to-upstream" -b openshift/${REPO_NAME}:release-next -h openshift/${REPO_NAME}:release-next-ci
 else


### PR DESCRIPTION
This will add to replace the flag variable in release-next
branch so that it has something to commit and
it will not fail at nothing to commit