### PR TITLE
[WIP] Add context path param to pipeline templates

### DIFF
--- a/deploy/resources/templates/pipelinetemplate.yaml
+++ b/deploy/resources/templates/pipelinetemplate.yaml
@@ -13,6 +13,8 @@ spec:
       type: string
     - name: IMAGE_NAME
       type: string
+    - name: PATH_CONTEXT
+      type: string
   workspaces:
     - name: workspace
 
@@ -45,6 +47,8 @@ spec:
       params:
         - name: IMAGE
           value: $(params.IMAGE_NAME)
+        - name: PATH_CONTEXT
+          value: $(params.PATH_CONTEXT)
         - name: TLSVERIFY
           value: "false"
 


### PR DESCRIPTION
When importing a Git repository in the OpenShift Console and enable the "Add Pipeline" checkbox the predefined pipeline `s2i-nodejs-deployment` in the namespace `openshift` was used as template for the new pipeline.

If I'm correct this is based [deploy/resources/addons/03-pipelines/deployment/s2i-nodejs/s2i-nodejs-build-deploy.yaml](https://github.com/openshift/tektoncd-pipeline-operator/blob/7ea98ae9224d2c4394ad81e7c6f78cc4ed2ce8e8/deploy/resources/addons/03-pipelines/deployment/s2i-nodejs/s2i-nodejs-build-deploy.yaml) and so on.

I added a new param `PATH_CONTEXT` to the pipelines which uses the task `s2i` (see [s2y.yaml in the tektoncd/catalog repo](https://github.com/tektoncd/catalog/blob/88bc2b5230108a060234fe9da9539ffccbe39607/task/s2i/0.1/s2i.yaml#L23-L25)) to build the application also if its not in the root directory of the git repository. Added the param to the `build` task as `PATH_CONTEXT` as well.

The same problem happen with the `buildah` task (see [buildah.yaml](https://github.com/tektoncd/catalog/blob/88bc2b5230108a060234fe9da9539ffccbe39607/task/buildah/0.1/buildah.yaml#L34-L36) also in the tektoncd/catalog repo). I added the same `PATH_CONTEXT` param to the pipeline and add it as `CONTEXT` to the `buildah` task.

And feedback or hints how to improve or solve this is welcome.