### PR TITLE
Update operator_v1alpha1_config_crd.yaml: Remove required 'pipelineVersion' and 'triggersVersion' fields

### DIFF
--- a/bundle/manifests/operator_v1alpha1_config_crd.yaml
+++ b/bundle/manifests/operator_v1alpha1_config_crd.yaml
@@ -53,8 +53,6 @@ spec:
                     type: string
                 required:
                 - code
-                - pipelineVersion
-                - triggersVersion
                 - version
                 type: object
               type: array


### PR DESCRIPTION
Fixes https://github.com/openshift/tektoncd-pipeline-operator/issues/449