### PR TITLE
Add role and rolebinding for openshift-pipelines namespace

### DIFF
--- a/deploy/resources/addons/03-pipelines/role.yaml
+++ b/deploy/resources/addons/03-pipelines/role.yaml
@@ -1,0 +1,9 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-default-openshift-pipelines-view
+  namespace: openshift-pipelines
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]

--- a/deploy/resources/addons/03-pipelines/rolebinding.yaml
+++ b/deploy/resources/addons/03-pipelines/rolebinding.yaml
@@ -13,3 +13,18 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:authenticated
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-default-openshift-pipelines-view
+  namespace: openshift-pipelines
+roleRef:
+  kind: Role
+  name: tekton-default-openshift-pipelines-view
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated


### PR DESCRIPTION
Jira : https://issues.redhat.com/browse/SRVKP-732

Added permission to `openshift-pipelines` namespace so that non-admin user can able to see `tkn version` info

Upstream PR:
https://github.com/tektoncd/cli/pull/1092
https://github.com/tektoncd/cli/pull/1186

/cc @piyush-garg @vdemeester @nikhil-thomas 

/hold

Until PR https://github.com/tektoncd/cli/pull/1186 merge