### PR TITLE
adds community tasks

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -26,6 +26,8 @@ spec:
           value: ""
         - name: IMAGE_ADDONS_PARAM_KN_IMAGE
           value: registry.redhat.io/openshift-serverless-1/client-kn-rhel8:0.13.2
+        - name: IMAGE_ADDONS_SKOPEO_COPY
+          value: registry.redhat.io/rhel8/skopeo:8.2
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -73,6 +73,13 @@ var (
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/maven/0.1/maven.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/tkn/0.1/tkn.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/kn/0.1/kn.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.1/helm-upgrade-from-source.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.1/helm-upgrade-from-repo.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/skopeo-copy/0.1/skopeo-copy.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-cli/0.1/git-cli.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/pull-request/0.1/pull-request.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/kubeconfig-creator/0.1/kubeconfig-creator.yaml",
 	}
 
 	Runtimes = map[string]RuntimeSpec{


### PR DESCRIPTION
this adds community tasks to operator as listed below
 - Helm install chart from source
 - Helm install chart from repo--
 - Skopeo--
 - Trigger Jenkins Job--
 - Git-cli
 - https://github.com/tektoncd/catalog/tree/master/task/pull-request
 - https://github.com/tektoncd/catalog/tree/master/task/kubeconfig-creator

Note: productized image for skopeo

Test:
set

export IMAGE_ADDONS_SKOPEO_COPY=registry.redhat.io/rhel8/skopeo

and run

operator-sdk up local --namespace=""