### PR TITLE
skip installation of tektoncd/catalog tasks if the platform is not x8…

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ ENV OPERATOR=/usr/local/bin/openshift-pipelines-operator \
     USER_NAME=openshift-pipelines-operator
 
 # install operator binary
-COPY build/_output/bin/tektoncd-pipeline-operator ${OPERATOR}
+COPY build/_output/bin/openshift-pipelines-operator ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ ENV OPERATOR=/usr/local/bin/openshift-pipelines-operator \
     USER_NAME=openshift-pipelines-operator
 
 # install operator binary
-COPY build/_output/bin/openshift-pipelines-operator ${OPERATOR}
+COPY build/_output/bin/tektoncd-pipeline-operator ${OPERATOR}
 
 COPY build/bin /usr/local/bin
 RUN  /usr/local/bin/user_setup

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -104,7 +104,7 @@ func readAddons(mgr manager.Manager) (mf.Manifest, error) {
 		return mf.Manifest{}, err
 	}
 	if runtime1.GOARCH == "ppc64le" || runtime1.GOARCH == "s390x" {
-                log.Info("skip installation of tektoncd/catalog tasks if the platform is not x86_64")
+                log.Info("skip installation of tektoncd/catalog tasks as the platform is not x86_64")
                 return mf.Manifest{}, nil
         }
 

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
+	runtime1 "runtime"
 	"github.com/go-logr/logr"
 	mf "github.com/jcrossley3/manifestival"
 	"github.com/operator-framework/operator-sdk/pkg/predicate"
@@ -103,6 +103,10 @@ func readAddons(mgr manager.Manager) (mf.Manifest, error) {
 	if err != nil {
 		return mf.Manifest{}, err
 	}
+	if runtime1.GOARCH == "ppc64le" || runtime1.GOARCH == "s390x" {
+                log.Info("skip installation of tektoncd/catalog tasks if the platform is not x86_64")
+                return mf.Manifest{}, nil
+        }
 
 	// add optionals to addons if any
 	optionalResources, err := readOptional(mgr)


### PR DESCRIPTION
Hi All,

As requested in https://github.com/openshift/tektoncd-pipeline-operator/issues/478 ticket , I have created PR to skip installation of tektoncd/catalog tasks if arch is Ppc64le and s360x. 

Also updated Docker file since noticed now binary name is tektoncd-pipeline-operator . 

-COPY build/_output/bin/openshift-pipelines-operator ${OPERATOR}
+COPY build/_output/bin/tektoncd-pipeline-operator ${OPERATOR}

Please review and let me know if any changes are needed. 

Thanks,
Snehlata Mohite. 

Thanks,
Snehlata Mohite. 

Thanks,
Snehlata Mohite. 

