### PR TITLE
Remove enable repo in Dockerfile

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -10,7 +10,7 @@ ENV GIT_COMMITTER_EMAIL pipelines-dev@redhat.com
 
 RUN yum install epel-release -y
 
-RUN yum --enablerepo=centosplus install -y  \
+RUN yum install -y  \
     findutils \
     git \
     make \


### PR DESCRIPTION
This will remove --enablerepo=centosplus in yum install step
as the build is failing with unknown repo centosplus error

image builds is working without this also