### PR TITLE
Skip upstream tasks when arch is P and Z, fix to branch v1.2.x

### DIFF
--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
+        goruntime "runtime"
 	"github.com/go-logr/logr"
 	mfc "github.com/manifestival/controller-runtime-client"
 	mf "github.com/manifestival/manifestival"
@@ -103,6 +103,10 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 
 func fetchCommuntiyResources(mgr manager.Manager) (mf.Manifest, error) {
 	if flag.SkipNonRedHatResources {
+		return mf.Manifest{}, nil
+	}
+	if goruntime.GOARCH == "ppc64le" || goruntime.GOARCH == "s390x" {
+		log.Info("skip installation of tektoncd/catalog tasks as the platform is not x86_64")
 		return mf.Manifest{}, nil
 	}
 	//manifestival can take urls/filepaths as input


### PR DESCRIPTION
Hi All,

As requested in https://github.com/openshift/tektoncd-pipeline-operator/pull/546 , updated code to skip installation of upstream tasks for P and Z.

Please review. 

Thanks,
Snehlata Mohite. 