### PR TITLE
Enable usage of tektoncd catalog tasks for s390x and ppc6le

### DIFF
--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"os"
 	"path/filepath"
-	goruntime "runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -103,10 +102,6 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 
 func fetchCommuntiyResources(mgr manager.Manager) (mf.Manifest, error) {
 	if flag.SkipNonRedHatResources {
-		return mf.Manifest{}, nil
-	}
-	if goruntime.GOARCH == "ppc64le" || goruntime.GOARCH == "s390x" {
-		log.Info("skip installation of tektoncd/catalog tasks as the platform is not x86_64")
 		return mf.Manifest{}, nil
 	}
 	//manifestival can take urls/filepaths as input

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -72,11 +72,11 @@ var (
 	Recursive              bool
 	OperatorUUID           string
 	CommunityResourceURLs  = []string{
-		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.1/jib-maven.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/jib-maven/0.2/jib-maven.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/maven/0.1/maven.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/tkn/0.1/tkn.yaml",
-		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.1/helm-upgrade-from-source.yaml",
-		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.1/helm-upgrade-from-repo.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-source/0.2/helm-upgrade-from-source.yaml",
+		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/helm-upgrade-from-repo/0.2/helm-upgrade-from-repo.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/trigger-jenkins-job/0.1/trigger-jenkins-job.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/git-cli/0.1/git-cli.yaml",
 		"https://raw.githubusercontent.com/tektoncd/catalog/master/task/pull-request/0.1/pull-request.yaml",


### PR DESCRIPTION
The catalog tasks addition was disabled for `s390x` and `ppc6le` architectures because tasks themselves failed for non Intel architectures.
Now all tasks from the list can be executed on `s390x` and `ppc64le` (in some case container images are multi-arched, for other cases there is special parameter to specify custom image specific to architecture).
For several tasks version has to be bumped from `0.1` to `0.2`, because custom image parameter is supported only in version `0.2`.

Signed-off-by: Yulia Gaponenko <yulia.gaponenko1@de.ibm.com>